### PR TITLE
:sparkles: (app) fix naming inconsistency, allow iso2 query option

### DIFF
--- a/controllers/dataHub/index.js
+++ b/controllers/dataHub/index.js
@@ -18,7 +18,13 @@ const getCountriesPopulation = () => {
       !accumulator[key] ? accumulator[key] = [item] : accumulator[key].push(item);
       return accumulator;
     }, {});
-    const final = Object.entries(result).map((x, i) => ({ country: x[0], code: x[1][0]['Country Code'], populationCounts: x[1].map((y) => ({ year: y.Year, value: y.Value })) }));
+
+    const final = Object.entries(result).map((x, i) => ({
+      country: x[0],
+      code: x[1][0]['Country Code'],
+      iso3: x[1][0]['Country Code'],
+      populationCounts: x[1].map((y) => ({ year: y.Year, value: y.Value }))
+    }));
     return final;
   });
 };

--- a/model/countriesAndCities.js
+++ b/model/countriesAndCities.js
@@ -5434,10 +5434,6 @@ const CountriesAndCities = [
     cities: ['Francistown', 'Gaborone', 'Orapa', 'Serowe', 'Village'],
   },
   {
-    country: 'Botswana',
-    cities: ['Olavtoppen', 'Kapp Valdivia', 'Kapp Circoncision', 'Nyrøysa', 'Kapp Norvegia', 'Larsøya', 'Kapp Fie', 'Kapp Lollo', 'Store Kari', 'Thompson Island'],
-  },
-  {
     country: 'Brazil',
     cities: [
       'Abadiania',
@@ -5982,7 +5978,7 @@ const CountriesAndCities = [
     ],
   },
   {
-    country: 'Burma',
+    country: 'Myanmar',
     cities: [
       'Ayeyarwady',
       'Bago',
@@ -32880,7 +32876,7 @@ const CountriesAndCities = [
     cities: [],
   },
   {
-    country: 'Hashemite Kingdom of Jordan',
+    country: 'Jordan',
     cities: [
       'Amman',
       'Ar Ramtha',
@@ -41483,7 +41479,7 @@ const CountriesAndCities = [
     cities: [],
   },
   {
-    country: 'Korea North',
+    country: 'North Korea',
     cities: [
       'Chagang',
       'North Hamgyong',
@@ -41498,27 +41494,6 @@ const CountriesAndCities = [
       'Najin',
       'Namp\'o',
       'Pyongyang',
-    ],
-  },
-  {
-    country: 'Korea South',
-    cities: [
-      'Seoul',
-      'Busan City',
-      'Daegu City',
-      'Incheon City',
-      'Gwangju City',
-      'Daejeon City',
-      'Ulsan',
-      'Gyeonggi Province',
-      'Gangwon Province',
-      'North Chungcheong Province',
-      'South Chungcheong Province',
-      'North Jeolla Province',
-      'South Jeolla Province',
-      'North Gyeongsang Province',
-      'South Gyeongsang Province',
-      'Jeju',
     ],
   },
   {
@@ -46129,6 +46104,15 @@ const CountriesAndCities = [
       'Vossestrand',
       'Vraliosen',
       'Ytre Alvik',
+      'Olavtoppen',
+      'Kapp Valdivia',
+      'Kapp Circoncision',
+      'Nyrøysa',
+      'Kapp Norvegia',
+      'Larsøya',
+      'Kapp Fie',
+      'Cape Lollo',
+      'Thompson Island',
     ],
   },
   {
@@ -49205,7 +49189,7 @@ const CountriesAndCities = [
     ],
   },
   {
-    country: 'Korea',
+    country: 'South Korea',
     cities: [
       'Andong',
       'Ansan-si',
@@ -49300,6 +49284,22 @@ const CountriesAndCities = [
       'Yeosu',
       'Yongin',
       'Yongsan-dong',
+      'Seoul',
+      'Busan City',
+      'Daegu City',
+      'Incheon City',
+      'Gwangju City',
+      'Daejeon City',
+      'Ulsan',
+      'Gyeonggi Province',
+      'Gangwon Province',
+      'North Chungcheong Province',
+      'South Chungcheong Province',
+      'North Jeolla Province',
+      'South Jeolla Province',
+      'North Gyeongsang Province',
+      'South Gyeongsang Province',
+      'Jeju',
     ],
   },
   {

--- a/model/countriesAndCodes.js
+++ b/model/countriesAndCodes.js
@@ -1,727 +1,727 @@
 const CountriesAndCodes = [
   {
-    name: 'Afghanistan', dial_code: '+93', code: 'AF', latitude: 33, longitude: 65,
+    name: 'Afghanistan', dial_code: '+93', iso2: 'AF', code: 'AF', latitude: 33, longitude: 65,
   },
   {
-    name: 'Albania', dial_code: '+355', code: 'AL', latitude: 41, longitude: 20,
+    name: 'Albania', dial_code: '+355', iso2: 'AL', code: 'AL', latitude: 41, longitude: 20,
   },
   {
-    name: 'Algeria', dial_code: '+213', code: 'DZ', latitude: 28, longitude: 3,
+    name: 'Algeria', dial_code: '+213', iso2: 'DZ', code: 'DZ', latitude: 28, longitude: 3,
   },
   {
-    name: 'AmericanSamoa', dial_code: '+1 684', code: 'AS', latitude: -14.3333, longitude: -170,
+    name: 'AmericanSamoa', dial_code: '+1 684', iso2: 'AS', code: 'AS', latitude: -14.3333, longitude: -170,
   },
   {
-    name: 'Andorra', dial_code: '+376', code: 'AD', latitude: 42.5, longitude: 1.6,
+    name: 'Andorra', dial_code: '+376', iso2: 'AD', code: 'AD', latitude: 42.5, longitude: 1.6,
   },
   {
-    name: 'Angola', dial_code: '+244', code: 'AO', latitude: -12.5, longitude: 18.5,
+    name: 'Angola', dial_code: '+244', iso2: 'AO', code: 'AO', latitude: -12.5, longitude: 18.5,
   },
   {
-    name: 'Anguilla', dial_code: '+1 264', code: 'AI', latitude: 18.25, longitude: -63.1667,
+    name: 'Anguilla', dial_code: '+1 264', iso2: 'AI', code: 'AI', latitude: 18.25, longitude: -63.1667,
   },
   {
-    name: 'Antarctica', dial_code: '+672', code: 'AQ', latitude: -90, longitude: '0',
+    name: 'Antarctica', dial_code: '+672', iso2: 'AQ', code: 'AQ', latitude: -90, longitude: '0',
   },
   {
-    name: 'Antigua and Barbuda', dial_code: '+1268', code: 'AG', latitude: 17.05, longitude: -61.8,
+    name: 'Antigua and Barbuda', dial_code: '+1268', iso2: 'AG', code: 'AG', latitude: 17.05, longitude: -61.8,
   },
   {
-    name: 'Argentina', dial_code: '+54', code: 'AR', latitude: -34, longitude: -64,
+    name: 'Argentina', dial_code: '+54', iso2: 'AR', code: 'AR', latitude: -34, longitude: -64,
   },
   {
-    name: 'Armenia', dial_code: '+374', code: 'AM', latitude: 40, longitude: 45,
+    name: 'Armenia', dial_code: '+374', iso2: 'AM', code: 'AM', latitude: 40, longitude: 45,
   },
   {
-    name: 'Aruba', dial_code: '+297', code: 'AW', latitude: 12.5, longitude: -69.9667,
+    name: 'Aruba', dial_code: '+297', iso2: 'AW', code: 'AW', latitude: 12.5, longitude: -69.9667,
   },
   {
-    name: 'Australia', dial_code: '+61', code: 'AU', latitude: -27, longitude: 133,
+    name: 'Australia', dial_code: '+61', iso2: 'AU', code: 'AU', latitude: -27, longitude: 133,
   },
   {
-    name: 'Austria', dial_code: '+43', code: 'AT', latitude: 47.3333, longitude: 13.3333,
+    name: 'Austria', dial_code: '+43', iso2: 'AT', code: 'AT', latitude: 47.3333, longitude: 13.3333,
   },
   {
-    name: 'Azerbaijan', dial_code: '+994', code: 'AZ', latitude: 40.5, longitude: 47.5,
+    name: 'Azerbaijan', dial_code: '+994', iso2: 'AZ', code: 'AZ', latitude: 40.5, longitude: 47.5,
   },
   {
-    name: 'Bahamas', dial_code: '+1 242', code: 'BS', latitude: 24.25, longitude: -76,
+    name: 'Bahamas', dial_code: '+1 242', iso2: 'BS', code: 'BS', latitude: 24.25, longitude: -76,
   },
   {
-    name: 'Bahrain', dial_code: '+973', code: 'BH', latitude: 26, longitude: 50.55,
+    name: 'Bahrain', dial_code: '+973', iso2: 'BH', code: 'BH', latitude: 26, longitude: 50.55,
   },
   {
-    name: 'Bangladesh', dial_code: '+880', code: 'BD', latitude: 24, longitude: 90,
+    name: 'Bangladesh', dial_code: '+880', iso2: 'BD', code: 'BD', latitude: 24, longitude: 90,
   },
   {
-    name: 'Barbados', dial_code: '+1 246', code: 'BB', latitude: 13.1667, longitude: -59.5333,
+    name: 'Barbados', dial_code: '+1 246', iso2: 'BB', code: 'BB', latitude: 13.1667, longitude: -59.5333,
   },
   {
-    name: 'Belarus', dial_code: '+375', code: 'BY', latitude: 53, longitude: 28,
+    name: 'Belarus', dial_code: '+375', iso2: 'BY', code: 'BY', latitude: 53, longitude: 28,
   },
   {
-    name: 'Belgium', dial_code: '+32', code: 'BE', latitude: 50.8333, longitude: 4,
+    name: 'Belgium', dial_code: '+32', iso2: 'BE', code: 'BE', latitude: 50.8333, longitude: 4,
   },
   {
-    name: 'Belize', dial_code: '+501', code: 'BZ', latitude: 17.25, longitude: -88.75,
+    name: 'Belize', dial_code: '+501', iso2: 'BZ', code: 'BZ', latitude: 17.25, longitude: -88.75,
   },
   {
-    name: 'Benin', dial_code: '+229', code: 'BJ', latitude: 9.5, longitude: 2.25,
+    name: 'Benin', dial_code: '+229', iso2: 'BJ', code: 'BJ', latitude: 9.5, longitude: 2.25,
   },
   {
-    name: 'Bermuda', dial_code: '+1 441', code: 'BM', latitude: 32.3333, longitude: -64.75,
+    name: 'Bermuda', dial_code: '+1 441', iso2: 'BM', code: 'BM', latitude: 32.3333, longitude: -64.75,
   },
   {
-    name: 'Bhutan', dial_code: '+975', code: 'BT', latitude: 27.5, longitude: 90.5,
+    name: 'Bhutan', dial_code: '+975', iso2: 'BT', code: 'BT', latitude: 27.5, longitude: 90.5,
   },
   {
-    name: 'Bolivia, Plurinational State of Bolivia', dial_code: '+591', code: 'BO', latitude: -17, longitude: -65,
+    name: 'Bolivia, Plurinational State of Bolivia', dial_code: '+591', iso2: 'BO', code: 'BO', latitude: -17, longitude: -65,
   },
   {
-    name: 'Bosnia and Herzegovina', dial_code: '+387', code: 'BA', latitude: 44, longitude: 18,
+    name: 'Bosnia and Herzegovina', dial_code: '+387', iso2: 'BA', code: 'BA', latitude: 44, longitude: 18,
   },
   {
-    name: 'Botswana', dial_code: '+267', code: 'BW', latitude: -22, longitude: 24,
+    name: 'Botswana', dial_code: '+267', iso2: 'BW', code: 'BW', latitude: -22, longitude: 24,
   },
   {
-    name: 'Bouvet Island', dial_code: '+55', code: 'BV', latitude: -54.4333, longitude: 3.4,
+    name: 'Bouvet Island', dial_code: '+55', iso2: 'BV', code: 'BV', latitude: -54.4333, longitude: 3.4,
   },
   {
-    name: 'Brazil', dial_code: '+55', code: 'BR', latitude: -10, longitude: -55,
+    name: 'Brazil', dial_code: '+55', iso2: 'BR', code: 'BR', latitude: -10, longitude: -55,
   },
   {
-    name: 'British Indian Ocean Territory', dial_code: '+246', code: 'IO', latitude: -6, longitude: 71.5,
+    name: 'British Indian Ocean Territory', dial_code: '+246', iso2: 'IO', code: 'IO', latitude: -6, longitude: 71.5,
   },
   {
-    name: 'Brunei Darussalam', dial_code: '+673', code: 'BN', latitude: 4.5, longitude: 114.6667,
+    name: 'Brunei Darussalam', dial_code: '+673', iso2: 'BN', code: 'BN', latitude: 4.5, longitude: 114.6667,
   },
   {
-    name: 'Bulgaria', dial_code: '+359', code: 'BG', latitude: 43, longitude: 25,
+    name: 'Bulgaria', dial_code: '+359', iso2: 'BG', code: 'BG', latitude: 43, longitude: 25,
   },
   {
-    name: 'Burkina Faso', dial_code: '+226', code: 'BF', latitude: 13, longitude: -2,
+    name: 'Burkina Faso', dial_code: '+226', iso2: 'BF', code: 'BF', latitude: 13, longitude: -2,
   },
   {
-    name: 'Burundi', dial_code: '+257', code: 'BI', latitude: -3.5, longitude: 30,
+    name: 'Burundi', dial_code: '+257', iso2: 'BI', code: 'BI', latitude: -3.5, longitude: 30,
   },
   {
-    name: 'Cambodia', dial_code: '+855', code: 'KH', latitude: 13, longitude: 105,
+    name: 'Cambodia', dial_code: '+855', iso2: 'KH', code: 'KH', latitude: 13, longitude: 105,
   },
   {
-    name: 'Cameroon', dial_code: '+237', code: 'CM', latitude: 6, longitude: 12,
+    name: 'Cameroon', dial_code: '+237', iso2: 'CM', code: 'CM', latitude: 6, longitude: 12,
   },
   {
-    name: 'Canada', dial_code: '+1', code: 'CA', latitude: 60, longitude: -95,
+    name: 'Canada', dial_code: '+1', iso2: 'CA', code: 'CA', latitude: 60, longitude: -95,
   },
   {
-    name: 'Cape Verde', dial_code: '+238', code: 'CV', latitude: 16, longitude: -24,
+    name: 'Cape Verde', dial_code: '+238', iso2: 'CV', code: 'CV', latitude: 16, longitude: -24,
   },
   {
-    name: 'Cayman Islands', dial_code: '+1345', code: 'KY', latitude: 19.5, longitude: -80.5,
+    name: 'Cayman Islands', dial_code: '+1345', iso2: 'KY', code: 'KY', latitude: 19.5, longitude: -80.5,
   },
   {
-    name: 'Central African Republic', dial_code: '+236', code: 'CF', latitude: 7, longitude: 21,
+    name: 'Central African Republic', dial_code: '+236', iso2: 'CF', code: 'CF', latitude: 7, longitude: 21,
   },
   {
-    name: 'Chad', dial_code: '+235', code: 'TD', latitude: 15, longitude: 19,
+    name: 'Chad', dial_code: '+235', iso2: 'TD', code: 'TD', latitude: 15, longitude: 19,
   },
   {
-    name: 'Chile', dial_code: '+56', code: 'CL', latitude: -30, longitude: -71,
+    name: 'Chile', dial_code: '+56', iso2: 'CL', code: 'CL', latitude: -30, longitude: -71,
   },
   {
-    name: 'China', dial_code: '+86', code: 'CN', latitude: 35, longitude: 105,
+    name: 'China', dial_code: '+86', iso2: 'CN', code: 'CN', latitude: 35, longitude: 105,
   },
   {
-    name: 'Christmas Island', dial_code: '+61', code: 'CX', latitude: -10.5, longitude: 105.6667,
+    name: 'Christmas Island', dial_code: '+61', iso2: 'CX', code: 'CX', latitude: -10.5, longitude: 105.6667,
   },
   {
-    name: 'Cocos (Keeling) Islands', dial_code: '+61', code: 'CC', latitude: -12.5, longitude: 96.8333,
+    name: 'Cocos (Keeling) Islands', dial_code: '+61', iso2: 'CC', code: 'CC', latitude: -12.5, longitude: 96.8333,
   },
   {
-    name: 'Colombia', dial_code: '+57', code: 'CO', latitude: 4, longitude: -72,
+    name: 'Colombia', dial_code: '+57', iso2: 'CO', code: 'CO', latitude: 4, longitude: -72,
   },
   {
-    name: 'Comoros', dial_code: '+269', code: 'KM', latitude: -12.1667, longitude: 44.25,
+    name: 'Comoros', dial_code: '+269', iso2: 'KM', code: 'KM', latitude: -12.1667, longitude: 44.25,
   },
   {
-    name: 'Congo', dial_code: '+242', code: 'CG', latitude: -1, longitude: 15,
+    name: 'Congo', dial_code: '+242', iso2: 'CG', code: 'CG', latitude: -1, longitude: 15,
   },
   {
-    name: 'Congo, The Democratic Republic of the', dial_code: '+243', code: 'CD', latitude: '0', longitude: 25,
+    name: 'Congo, The Democratic Republic of the', dial_code: '+243', iso2: 'CD', code: 'CD', latitude: '0', longitude: 25,
   },
   {
-    name: 'Cook Islands', dial_code: '+682', code: 'CK', latitude: -21.2333, longitude: -159.7667,
+    name: 'Cook Islands', dial_code: '+682', iso2: 'CK', code: 'CK', latitude: -21.2333, longitude: -159.7667,
   },
   {
-    name: 'Costa Rica', dial_code: '+506', code: 'CR', latitude: 10, longitude: -84,
+    name: 'Costa Rica', dial_code: '+506', iso2: 'CR', code: 'CR', latitude: 10, longitude: -84,
   },
   {
-    name: 'Cote d\'Ivoire', dial_code: '+225', code: 'CI', latitude: 8, longitude: -5,
+    name: 'Ivory Coast', dial_code: '+225', iso2: 'CI', code: 'CI', latitude: 8, longitude: -5,
   },
   {
-    name: 'Croatia', dial_code: '+385', code: 'HR', latitude: 45.1667, longitude: 15.5,
+    name: 'Croatia', dial_code: '+385', iso2: 'HR', code: 'HR', latitude: 45.1667, longitude: 15.5,
   },
   {
-    name: 'Cuba', dial_code: '+53', code: 'CU', latitude: 21.5, longitude: -80,
+    name: 'Cuba', dial_code: '+53', iso2: 'CU', code: 'CU', latitude: 21.5, longitude: -80,
   },
   {
-    name: 'Cyprus', dial_code: '+357', code: 'CY', latitude: 35, longitude: 33,
+    name: 'Cyprus', dial_code: '+357', iso2: 'CY', code: 'CY', latitude: 35, longitude: 33,
   },
   {
-    name: 'Czech Republic', dial_code: '+420', code: 'CZ', latitude: 49.75, longitude: 15.5,
+    name: 'Czech Republic', dial_code: '+420', iso2: 'CZ', code: 'CZ', latitude: 49.75, longitude: 15.5,
   },
   {
-    name: 'Denmark', dial_code: '+45', code: 'DK', latitude: 56, longitude: 10,
+    name: 'Denmark', dial_code: '+45', iso2: 'DK', code: 'DK', latitude: 56, longitude: 10,
   },
   {
-    name: 'Djibouti', dial_code: '+253', code: 'DJ', latitude: 11.5, longitude: 43,
+    name: 'Djibouti', dial_code: '+253', iso2: 'DJ', code: 'DJ', latitude: 11.5, longitude: 43,
   },
   {
-    name: 'Dominica', dial_code: '+1 767', code: 'DM', latitude: 15.4167, longitude: -61.3333,
+    name: 'Dominica', dial_code: '+1 767', iso2: 'DM', code: 'DM', latitude: 15.4167, longitude: -61.3333,
   },
   {
-    name: 'Dominican Republic', dial_code: '+1 849', code: 'DO', latitude: 19, longitude: -70.6667,
+    name: 'Dominican Republic', dial_code: '+1 849', iso2: 'DO', code: 'DO', latitude: 19, longitude: -70.6667,
   },
   {
-    name: 'Ecuador', dial_code: '+593', code: 'EC', latitude: -2, longitude: -77.5,
+    name: 'Ecuador', dial_code: '+593', iso2: 'EC', code: 'EC', latitude: -2, longitude: -77.5,
   },
   {
-    name: 'Egypt', dial_code: '+20', code: 'EG', latitude: 27, longitude: 30,
+    name: 'Egypt', dial_code: '+20', iso2: 'EG', code: 'EG', latitude: 27, longitude: 30,
   },
   {
-    name: 'El Salvador', dial_code: '+503', code: 'SV', latitude: 13.8333, longitude: -88.9167,
+    name: 'El Salvador', dial_code: '+503', iso2: 'SV', code: 'SV', latitude: 13.8333, longitude: -88.9167,
   },
   {
-    name: 'Equatorial Guinea', dial_code: '+240', code: 'GQ', latitude: 2, longitude: 10,
+    name: 'Equatorial Guinea', dial_code: '+240', iso2: 'GQ', code: 'GQ', latitude: 2, longitude: 10,
   },
   {
-    name: 'Eritrea', dial_code: '+291', code: 'ER', latitude: 15, longitude: 39,
+    name: 'Eritrea', dial_code: '+291', iso2: 'ER', code: 'ER', latitude: 15, longitude: 39,
   },
   {
-    name: 'Estonia', dial_code: '+372', code: 'EE', latitude: 59, longitude: 26,
+    name: 'Estonia', dial_code: '+372', iso2: 'EE', code: 'EE', latitude: 59, longitude: 26,
   },
   {
-    name: 'Ethiopia', dial_code: '+251', code: 'ET', latitude: 8, longitude: 38,
+    name: 'Ethiopia', dial_code: '+251', iso2: 'ET', code: 'ET', latitude: 8, longitude: 38,
   },
   {
-    name: 'Falkland Islands', dial_code: '+500', code: 'FK', latitude: -51.75, longitude: -59,
+    name: 'Falkland Islands', dial_code: '+500', iso2: 'FK', code: 'FK', latitude: -51.75, longitude: -59,
   },
   {
-    name: 'Faroe Islands', dial_code: '+298', code: 'FO', latitude: 62, longitude: -7,
+    name: 'Faroe Islands', dial_code: '+298', iso2: 'FO', code: 'FO', latitude: 62, longitude: -7,
   },
   {
-    name: 'Fiji', dial_code: '+679', code: 'FJ', latitude: -18, longitude: 175,
+    name: 'Fiji', dial_code: '+679', iso2: 'FJ', code: 'FJ', latitude: -18, longitude: 175,
   },
   {
-    name: 'Finland', dial_code: '+358', code: 'FI', latitude: 64, longitude: 26,
+    name: 'Finland', dial_code: '+358', iso2: 'FI', code: 'FI', latitude: 64, longitude: 26,
   },
   {
-    name: 'France', dial_code: '+33', code: 'FR', latitude: 46, longitude: 2,
+    name: 'France', dial_code: '+33', iso2: 'FR', code: 'FR', latitude: 46, longitude: 2,
   },
   {
-    name: 'French Polynesia', dial_code: '+689', code: 'PF', latitude: -15, longitude: -140,
+    name: 'French Polynesia', dial_code: '+689', iso2: 'PF', code: 'PF', latitude: -15, longitude: -140,
   },
   {
-    name: 'French Southern and Antarctic Lands', dial_code: '+262', code: 'TF', latitude: -43, longitude: 67,
+    name: 'French Southern and Antarctic Lands', dial_code: '+262', iso2: 'TF', code: 'TF', latitude: -43, longitude: 67,
   },
   {
-    name: 'Gabon', dial_code: '+241', code: 'GA', latitude: -1, longitude: 11.75,
+    name: 'Gabon', dial_code: '+241', iso2: 'GA', code: 'GA', latitude: -1, longitude: 11.75,
   },
   {
-    name: 'Gambia', dial_code: '+220', code: 'GM', latitude: 13.4667, longitude: -16.5667,
+    name: 'Gambia', dial_code: '+220', iso2: 'GM', code: 'GM', latitude: 13.4667, longitude: -16.5667,
   },
   {
-    name: 'Georgia', dial_code: '+995', code: 'GE', latitude: 42, longitude: 43.5,
+    name: 'Georgia', dial_code: '+995', iso2: 'GE', code: 'GE', latitude: 42, longitude: 43.5,
   },
   {
-    name: 'Germany', dial_code: '+49', code: 'DE', latitude: 51, longitude: 9,
+    name: 'Germany', dial_code: '+49', iso2: 'DE', code: 'DE', latitude: 51, longitude: 9,
   },
   {
-    name: 'Ghana', dial_code: '+233', code: 'GH', latitude: 8, longitude: -2,
+    name: 'Ghana', dial_code: '+233', iso2: 'GH', code: 'GH', latitude: 8, longitude: -2,
   },
   {
-    name: 'Gibraltar', dial_code: '+350', code: 'GI', latitude: 36.1833, longitude: -5.3667,
+    name: 'Gibraltar', dial_code: '+350', iso2: 'GI', code: 'GI', latitude: 36.1833, longitude: -5.3667,
   },
   {
-    name: 'Greece', dial_code: '+30', code: 'EL', latitude: 39, longitude: 22,
+    name: 'Greece', dial_code: '+30', iso2: 'EL', code: 'EL', latitude: 39, longitude: 22,
   },
   {
-    name: 'Greenland', dial_code: '+299', code: 'GL', latitude: 72, longitude: -40,
+    name: 'Greenland', dial_code: '+299', iso2: 'GL', code: 'GL', latitude: 72, longitude: -40,
   },
   {
-    name: 'Grenada', dial_code: '+1 473', code: 'GD', latitude: 12.1167, longitude: -61.6667,
+    name: 'Grenada', dial_code: '+1 473', iso2: 'GD', code: 'GD', latitude: 12.1167, longitude: -61.6667,
   },
   {
-    name: 'Guadeloupe', dial_code: '+590', code: 'GP', latitude: 16.25, longitude: -61.5833,
+    name: 'Guadeloupe', dial_code: '+590', iso2: 'GP', code: 'GP', latitude: 16.25, longitude: -61.5833,
   },
   {
-    name: 'Guam', dial_code: '+1 671', code: 'GU', latitude: 13.4667, longitude: 144.7833,
+    name: 'Guam', dial_code: '+1 671', iso2: 'GU', code: 'GU', latitude: 13.4667, longitude: 144.7833,
   },
   {
-    name: 'Guatemala', dial_code: '+502', code: 'GT', latitude: 15.5, longitude: -90.25,
+    name: 'Guatemala', dial_code: '+502', iso2: 'GT', code: 'GT', latitude: 15.5, longitude: -90.25,
   },
   {
-    name: 'Guernsey', dial_code: '+44', code: 'GG', latitude: 49.5, longitude: -2.56,
+    name: 'Guernsey', dial_code: '+44', iso2: 'GG', code: 'GG', latitude: 49.5, longitude: -2.56,
   },
   {
-    name: 'Guinea', dial_code: '+224', code: 'GN', latitude: 11, longitude: -10,
+    name: 'Guinea', dial_code: '+224', iso2: 'GN', code: 'GN', latitude: 11, longitude: -10,
   },
   {
-    name: 'Guinea-Bissau', dial_code: '+245', code: 'GW', latitude: 12, longitude: -15,
+    name: 'Guinea-Bissau', dial_code: '+245', iso2: 'GW', code: 'GW', latitude: 12, longitude: -15,
   },
   {
-    name: 'Guyana', dial_code: '+592', code: 'GY', latitude: 5, longitude: -59,
+    name: 'Guyana', dial_code: '+592', iso2: 'GY', code: 'GY', latitude: 5, longitude: -59,
   },
   {
-    name: 'Haiti', dial_code: '+509', code: 'HT', latitude: 19, longitude: -72.4167,
+    name: 'Haiti', dial_code: '+509', iso2: 'HT', code: 'HT', latitude: 19, longitude: -72.4167,
   },
   {
-    name: 'Heard Island and McDonald Islands', dial_code: '+672', code: 'HM', latitude: -53.1, longitude: 72.5167,
+    name: 'Heard Island and McDonald Islands', dial_code: '+672', iso2: 'HM', code: 'HM', latitude: -53.1, longitude: 72.5167,
   },
   {
-    name: 'Vatican City State (Holy See)', dial_code: '+379', code: 'VA', latitude: 41.9, longitude: 12.45,
+    name: 'Vatican City State (Holy See)', dial_code: '+379', iso2: 'VA', code: 'VA', latitude: 41.9, longitude: 12.45,
   },
   {
-    name: 'Honduras', dial_code: '+504', code: 'HN', latitude: 15, longitude: -86.5,
+    name: 'Honduras', dial_code: '+504', iso2: 'HN', code: 'HN', latitude: 15, longitude: -86.5,
   },
   {
-    name: 'Hong Kong', dial_code: '+852', code: 'HK', latitude: 22.25, longitude: 114.1667,
+    name: 'Hong Kong', dial_code: '+852', iso2: 'HK', code: 'HK', latitude: 22.25, longitude: 114.1667,
   },
   {
-    name: 'Hungary', dial_code: '+36', code: 'HU', latitude: 47, longitude: 20,
+    name: 'Hungary', dial_code: '+36', iso2: 'HU', code: 'HU', latitude: 47, longitude: 20,
   },
   {
-    name: 'Iceland', dial_code: '+354', code: 'IS', latitude: 65, longitude: -18,
+    name: 'Iceland', dial_code: '+354', iso2: 'IS', code: 'IS', latitude: 65, longitude: -18,
   },
   {
-    name: 'India', dial_code: '+91', code: 'IN', latitude: 20, longitude: 77,
+    name: 'India', dial_code: '+91', iso2: 'IN', code: 'IN', latitude: 20, longitude: 77,
   },
   {
-    name: 'Indonesia', dial_code: '+62', code: 'ID', latitude: -5, longitude: 120,
+    name: 'Indonesia', dial_code: '+62', iso2: 'ID', code: 'ID', latitude: -5, longitude: 120,
   },
   {
-    name: 'Iran, Islamic Republic of', dial_code: '+98', code: 'IR', latitude: 32, longitude: 53,
+    name: 'Iran, Islamic Republic of', dial_code: '+98', iso2: 'IR', code: 'IR', latitude: 32, longitude: 53,
   },
   {
-    name: 'Iraq', dial_code: '+964', code: 'IQ', latitude: 33, longitude: 44,
+    name: 'Iraq', dial_code: '+964', iso2: 'IQ', code: 'IQ', latitude: 33, longitude: 44,
   },
   {
-    name: 'Ireland', dial_code: '+353', code: 'IE', latitude: 53, longitude: -8,
+    name: 'Ireland', dial_code: '+353', iso2: 'IE', code: 'IE', latitude: 53, longitude: -8,
   },
   {
-    name: 'Isle of Man', dial_code: '+44', code: 'IM', latitude: 54.23, longitude: -4.55,
+    name: 'Isle of Man', dial_code: '+44', iso2: 'IM', code: 'IM', latitude: 54.23, longitude: -4.55,
   },
   {
-    name: 'Israel', dial_code: '+972', code: 'IL', latitude: 31.5, longitude: 34.75,
+    name: 'Israel', dial_code: '+972', iso2: 'IL', code: 'IL', latitude: 31.5, longitude: 34.75,
   },
   {
-    name: 'Italy', dial_code: '+39', code: 'IT', latitude: 42.8333, longitude: 12.8333,
+    name: 'Italy', dial_code: '+39', iso2: 'IT', code: 'IT', latitude: 42.8333, longitude: 12.8333,
   },
   {
-    name: 'Jamaica', dial_code: '+1 876', code: 'JM', latitude: 18.25, longitude: -77.5,
+    name: 'Jamaica', dial_code: '+1 876', iso2: 'JM', code: 'JM', latitude: 18.25, longitude: -77.5,
   },
   {
-    name: 'Japan', dial_code: '+81', code: 'JP', latitude: 36, longitude: 138,
+    name: 'Japan', dial_code: '+81', iso2: 'JP', code: 'JP', latitude: 36, longitude: 138,
   },
   {
-    name: 'Jersey', dial_code: '+44', code: 'JE', latitude: 49.21, longitude: -2.13,
+    name: 'Jersey', dial_code: '+44', iso2: 'JE', code: 'JE', latitude: 49.21, longitude: -2.13,
   },
   {
-    name: 'Jordan', dial_code: '+962', code: 'JO', latitude: 31, longitude: 36,
+    name: 'Jordan', dial_code: '+962', iso2: 'JO', code: 'JO', latitude: 31, longitude: 36,
   },
   {
-    name: 'Kazakhstan', dial_code: '+7', code: 'KZ', latitude: 48, longitude: 68,
+    name: 'Kazakhstan', dial_code: '+7', iso2: 'KZ', code: 'KZ', latitude: 48, longitude: 68,
   },
   {
-    name: 'Kenya', dial_code: '+254', code: 'KE', latitude: 1, longitude: 38,
+    name: 'Kenya', dial_code: '+254', iso2: 'KE', code: 'KE', latitude: 1, longitude: 38,
   },
   {
-    name: 'Kiribati', dial_code: '+686', code: 'KI', latitude: 1.4167, longitude: 173,
+    name: 'Kiribati', dial_code: '+686', iso2: 'KI', code: 'KI', latitude: 1.4167, longitude: 173,
   },
   {
-    name: 'Korea, Democratic People\'s Republic of', dial_code: '+850', code: 'KP', latitude: 40, longitude: 127,
+    name: 'North Korea', dial_code: '+850', iso2: 'KP', code: 'KP', latitude: 40, longitude: 127,
   },
   {
-    name: 'Korea, Republic of', dial_code: '+82', code: 'KR', latitude: 37, longitude: 127.5,
+    name: 'South Korea', dial_code: '+82', iso2: 'KR', code: 'KR', latitude: 37, longitude: 127.5,
   },
   {
-    name: 'Kuwait', dial_code: '+965', code: 'KW', latitude: 29.3375, longitude: 47.6581,
+    name: 'Kuwait', dial_code: '+965', iso2: 'KW', code: 'KW', latitude: 29.3375, longitude: 47.6581,
   },
   {
-    name: 'Kyrgyzstan', dial_code: '+996', code: 'KG', latitude: 41, longitude: 75,
+    name: 'Kyrgyzstan', dial_code: '+996', iso2: 'KG', code: 'KG', latitude: 41, longitude: 75,
   },
   {
-    name: 'Laos', dial_code: '+856', code: 'LA', latitude: 18, longitude: 105,
+    name: 'Laos', dial_code: '+856', iso2: 'LA', code: 'LA', latitude: 18, longitude: 105,
   },
   {
-    name: 'Latvia', dial_code: '+371', code: 'LV', latitude: 57, longitude: 25,
+    name: 'Latvia', dial_code: '+371', iso2: 'LV', code: 'LV', latitude: 57, longitude: 25,
   },
   {
-    name: 'Lebanon', dial_code: '+961', code: 'LB', latitude: 33.8333, longitude: 35.8333,
+    name: 'Lebanon', dial_code: '+961', iso2: 'LB', code: 'LB', latitude: 33.8333, longitude: 35.8333,
   },
   {
-    name: 'Lesotho', dial_code: '+266', code: 'LS', latitude: -29.5, longitude: 28.5,
+    name: 'Lesotho', dial_code: '+266', iso2: 'LS', code: 'LS', latitude: -29.5, longitude: 28.5,
   },
   {
-    name: 'Liberia', dial_code: '+231', code: 'LR', latitude: 6.5, longitude: -9.5,
+    name: 'Liberia', dial_code: '+231', iso2: 'LR', code: 'LR', latitude: 6.5, longitude: -9.5,
   },
   {
-    name: 'Libyan Arab Jamahiriya', dial_code: '+218', code: 'LY', latitude: 25, longitude: 17,
+    name: 'Libyan Arab Jamahiriya', dial_code: '+218', iso2: 'LY', code: 'LY', latitude: 25, longitude: 17,
   },
   {
-    name: 'Liechtenstein', dial_code: '+423', code: 'LI', latitude: 47.1667, longitude: 9.5333,
+    name: 'Liechtenstein', dial_code: '+423', iso2: 'LI', code: 'LI', latitude: 47.1667, longitude: 9.5333,
   },
   {
-    name: 'Lithuania', dial_code: '+370', code: 'LT', latitude: 56, longitude: 24,
+    name: 'Lithuania', dial_code: '+370', iso2: 'LT', code: 'LT', latitude: 56, longitude: 24,
   },
   {
-    name: 'Luxembourg', dial_code: '+352', code: 'LU', latitude: 49.75, longitude: 6.1667,
+    name: 'Luxembourg', dial_code: '+352', iso2: 'LU', code: 'LU', latitude: 49.75, longitude: 6.1667,
   },
   {
-    name: 'Macau', dial_code: '+853', code: 'MO', latitude: 22.1667, longitude: 113.55,
+    name: 'Macau', dial_code: '+853', iso2: 'MO', code: 'MO', latitude: 22.1667, longitude: 113.55,
   },
   {
-    name: 'Macedonia, The Former Yugoslav Republic of', dial_code: '+389', code: 'MK', latitude: 41.8333, longitude: 22,
+    name: 'Macedonia, The Former Yugoslav Republic of', dial_code: '+389', iso2: 'MK', code: 'MK', latitude: 41.8333, longitude: 22,
   },
   {
-    name: 'Madagascar', dial_code: '+261', code: 'MG', latitude: -20, longitude: 47,
+    name: 'Madagascar', dial_code: '+261', iso2: 'MG', code: 'MG', latitude: -20, longitude: 47,
   },
   {
-    name: 'Malawi', dial_code: '+265', code: 'MW', latitude: -13.5, longitude: 34,
+    name: 'Malawi', dial_code: '+265', iso2: 'MW', code: 'MW', latitude: -13.5, longitude: 34,
   },
   {
-    name: 'Malaysia', dial_code: '+60', code: 'MY', latitude: 2.5, longitude: 112.5,
+    name: 'Malaysia', dial_code: '+60', iso2: 'MY', code: 'MY', latitude: 2.5, longitude: 112.5,
   },
   {
-    name: 'Maldives', dial_code: '+960', code: 'MV', latitude: 3.25, longitude: 73,
+    name: 'Maldives', dial_code: '+960', iso2: 'MV', code: 'MV', latitude: 3.25, longitude: 73,
   },
   {
-    name: 'Mali', dial_code: '+223', code: 'ML', latitude: 17, longitude: -4,
+    name: 'Mali', dial_code: '+223', iso2: 'ML', code: 'ML', latitude: 17, longitude: -4,
   },
   {
-    name: 'Malta', dial_code: '+356', code: 'MT', latitude: 35.8333, longitude: 14.5833,
+    name: 'Malta', dial_code: '+356', iso2: 'MT', code: 'MT', latitude: 35.8333, longitude: 14.5833,
   },
   {
-    name: 'Marshall Islands', dial_code: '+692', code: 'MH', latitude: 9, longitude: 168,
+    name: 'Marshall Islands', dial_code: '+692', iso2: 'MH', code: 'MH', latitude: 9, longitude: 168,
   },
   {
-    name: 'Martinique', dial_code: '+596', code: 'MQ', latitude: 14.6667, longitude: -61,
+    name: 'Martinique', dial_code: '+596', iso2: 'MQ', code: 'MQ', latitude: 14.6667, longitude: -61,
   },
   {
-    name: 'Mauritania', dial_code: '+222', code: 'MR', latitude: 20, longitude: -12,
+    name: 'Mauritania', dial_code: '+222', iso2: 'MR', code: 'MR', latitude: 20, longitude: -12,
   },
   {
-    name: 'Mauritius', dial_code: '+230', code: 'MU', latitude: -20.2833, longitude: 57.55,
+    name: 'Mauritius', dial_code: '+230', iso2: 'MU', code: 'MU', latitude: -20.2833, longitude: 57.55,
   },
   {
-    name: 'Mayotte', dial_code: '+262', code: 'YT', latitude: -12.8333, longitude: 45.1667,
+    name: 'Mayotte', dial_code: '+262', iso2: 'YT', code: 'YT', latitude: -12.8333, longitude: 45.1667,
   },
   {
-    name: 'Mexico', dial_code: '+52', code: 'MX', latitude: 23, longitude: -102,
+    name: 'Mexico', dial_code: '+52', iso2: 'MX', code: 'MX', latitude: 23, longitude: -102,
   },
   {
-    name: 'Micronesia, Federated States of', dial_code: '+691', code: 'FM', latitude: 6.9167, longitude: 158.25,
+    name: 'Micronesia, Federated States of', dial_code: '+691', iso2: 'FM', code: 'FM', latitude: 6.9167, longitude: 158.25,
   },
   {
-    name: 'Moldova, Republic of', dial_code: '+373', code: 'MD', latitude: 47, longitude: 29,
+    name: 'Moldova, Republic of', dial_code: '+373', iso2: 'MD', code: 'MD', latitude: 47, longitude: 29,
   },
   {
-    name: 'Monaco', dial_code: '+377', code: 'MC', latitude: 43.7333, longitude: 7.4,
+    name: 'Monaco', dial_code: '+377', iso2: 'MC', code: 'MC', latitude: 43.7333, longitude: 7.4,
   },
   {
-    name: 'Mongolia', dial_code: '+976', code: 'MN', latitude: 46, longitude: 105,
+    name: 'Mongolia', dial_code: '+976', iso2: 'MN', code: 'MN', latitude: 46, longitude: 105,
   },
   {
-    name: 'Montenegro', dial_code: '+382', code: 'ME', latitude: 42, longitude: 19,
+    name: 'Montenegro', dial_code: '+382', iso2: 'ME', code: 'ME', latitude: 42, longitude: 19,
   },
   {
-    name: 'Montserrat', dial_code: '+1664', code: 'MS', latitude: 16.75, longitude: -62.2,
+    name: 'Montserrat', dial_code: '+1664', iso2: 'MS', code: 'MS', latitude: 16.75, longitude: -62.2,
   },
   {
-    name: 'Morocco', dial_code: '+212', code: 'MA', latitude: 32, longitude: -5,
+    name: 'Morocco', dial_code: '+212', iso2: 'MA', code: 'MA', latitude: 32, longitude: -5,
   },
   {
-    name: 'Mozambique', dial_code: '+258', code: 'MZ', latitude: -18.25, longitude: 35,
+    name: 'Mozambique', dial_code: '+258', iso2: 'MZ', code: 'MZ', latitude: -18.25, longitude: 35,
   },
   {
-    name: 'Myanmar', dial_code: '+95', code: 'MM', latitude: 22, longitude: 98,
+    name: 'Myanmar', dial_code: '+95', iso2: 'MM', code: 'MM', latitude: 22, longitude: 98,
   },
   {
-    name: 'Namibia', dial_code: '+264', code: 'NA', latitude: -22, longitude: 17,
+    name: 'Namibia', dial_code: '+264', iso2: 'NA', code: 'NA', latitude: -22, longitude: 17,
   },
   {
-    name: 'Nauru', dial_code: '+674', code: 'NR', latitude: -0.5333, longitude: 166.9167,
+    name: 'Nauru', dial_code: '+674', iso2: 'NR', code: 'NR', latitude: -0.5333, longitude: 166.9167,
   },
   {
-    name: 'Nepal', dial_code: '+977', code: 'NP', latitude: 28, longitude: 84,
+    name: 'Nepal', dial_code: '+977', iso2: 'NP', code: 'NP', latitude: 28, longitude: 84,
   },
   {
-    name: 'Netherlands', dial_code: '+31', code: 'NL', latitude: 52.5, longitude: 5.75,
+    name: 'Netherlands', dial_code: '+31', iso2: 'NL', code: 'NL', latitude: 52.5, longitude: 5.75,
   },
   {
-    name: 'Netherlands Antilles', dial_code: '+599', code: 'AN', latitude: 12.25, longitude: -68.75,
+    name: 'Netherlands Antilles', dial_code: '+599', iso2: 'AN', code: 'AN', latitude: 12.25, longitude: -68.75,
   },
   {
-    name: 'New Caledonia', dial_code: '+687', code: 'NC', latitude: -21.5, longitude: 165.5,
+    name: 'New Caledonia', dial_code: '+687', iso2: 'NC', code: 'NC', latitude: -21.5, longitude: 165.5,
   },
   {
-    name: 'New Zealand', dial_code: '+64', code: 'NZ', latitude: -41, longitude: 174,
+    name: 'New Zealand', dial_code: '+64', iso2: 'NZ', code: 'NZ', latitude: -41, longitude: 174,
   },
   {
-    name: 'Nicaragua', dial_code: '+505', code: 'NI', latitude: 13, longitude: -85,
+    name: 'Nicaragua', dial_code: '+505', iso2: 'NI', code: 'NI', latitude: 13, longitude: -85,
   },
   {
-    name: 'Niger', dial_code: '+227', code: 'NE', latitude: 16, longitude: 8,
+    name: 'Niger', dial_code: '+227', iso2: 'NE', code: 'NE', latitude: 16, longitude: 8,
   },
   {
-    name: 'Nigeria', dial_code: '+234', code: 'NG', latitude: 10, longitude: 8,
+    name: 'Nigeria', dial_code: '+234', iso2: 'NG', code: 'NG', latitude: 10, longitude: 8,
   },
   {
-    name: 'Niue', dial_code: '+683', code: 'NU', latitude: -19.0333, longitude: -169.8667,
+    name: 'Niue', dial_code: '+683', iso2: 'NU', code: 'NU', latitude: -19.0333, longitude: -169.8667,
   },
   {
-    name: 'Norfolk Island', dial_code: '+672', code: 'NF', latitude: -29.0333, longitude: 167.95,
+    name: 'Norfolk Island', dial_code: '+672', iso2: 'NF', code: 'NF', latitude: -29.0333, longitude: 167.95,
   },
   {
-    name: 'Northern Mariana Islands', dial_code: '+1 670', code: 'MP', latitude: 15.2, longitude: 145.75,
+    name: 'Northern Mariana Islands', dial_code: '+1 670', iso2: 'MP', code: 'MP', latitude: 15.2, longitude: 145.75,
   },
   {
-    name: 'Norway', dial_code: '+47', code: 'NO', latitude: 62, longitude: 10,
+    name: 'Norway', dial_code: '+47', iso2: 'NO', code: 'NO', latitude: 62, longitude: 10,
   },
   {
-    name: 'Oman', dial_code: '+968', code: 'OM', latitude: 21, longitude: 57,
+    name: 'Oman', dial_code: '+968', iso2: 'OM', code: 'OM', latitude: 21, longitude: 57,
   },
   {
-    name: 'Pakistan', dial_code: '+92', code: 'PK', latitude: 30, longitude: 70,
+    name: 'Pakistan', dial_code: '+92', iso2: 'PK', code: 'PK', latitude: 30, longitude: 70,
   },
   {
-    name: 'Palau', dial_code: '+680', code: 'PW', latitude: 7.5, longitude: 134.5,
+    name: 'Palau', dial_code: '+680', iso2: 'PW', code: 'PW', latitude: 7.5, longitude: 134.5,
   },
   {
-    name: 'Palestinian Territory, Occupied', dial_code: '+970', code: 'PS', latitude: 32, longitude: 35.25,
+    name: 'Palestinian Territory, Occupied', dial_code: '+970', iso2: 'PS', code: 'PS', latitude: 32, longitude: 35.25,
   },
   {
-    name: 'Panama', dial_code: '+507', code: 'PA', latitude: 9, longitude: -80,
+    name: 'Panama', dial_code: '+507', iso2: 'PA', code: 'PA', latitude: 9, longitude: -80,
   },
   {
-    name: 'Papua New Guinea', dial_code: '+675', code: 'PG', latitude: -6, longitude: 147,
+    name: 'Papua New Guinea', dial_code: '+675', iso2: 'PG', code: 'PG', latitude: -6, longitude: 147,
   },
   {
-    name: 'Paraguay', dial_code: '+595', code: 'PY', latitude: -23, longitude: -58,
+    name: 'Paraguay', dial_code: '+595', iso2: 'PY', code: 'PY', latitude: -23, longitude: -58,
   },
   {
-    name: 'Peru', dial_code: '+51', code: 'PE', latitude: -10, longitude: -76,
+    name: 'Peru', dial_code: '+51', iso2: 'PE', code: 'PE', latitude: -10, longitude: -76,
   },
   {
-    name: 'Philippines', dial_code: '+63', code: 'PH', latitude: 13, longitude: 122,
+    name: 'Philippines', dial_code: '+63', iso2: 'PH', code: 'PH', latitude: 13, longitude: 122,
   },
   {
-    name: 'Pitcairn', dial_code: '+870', code: 'PN', latitude: -24.7, longitude: -127.4,
+    name: 'Pitcairn', dial_code: '+870', iso2: 'PN', code: 'PN', latitude: -24.7, longitude: -127.4,
   },
   {
-    name: 'Poland', dial_code: '+48', code: 'PL', latitude: 52, longitude: 20,
+    name: 'Poland', dial_code: '+48', iso2: 'PL', code: 'PL', latitude: 52, longitude: 20,
   },
   {
-    name: 'Portugal', dial_code: '+351', code: 'PT', latitude: 39.5, longitude: -8,
+    name: 'Portugal', dial_code: '+351', iso2: 'PT', code: 'PT', latitude: 39.5, longitude: -8,
   },
   {
-    name: 'Puerto Rico', dial_code: '+1 939', code: 'PR', latitude: 18.25, longitude: -66.5,
+    name: 'Puerto Rico', dial_code: '+1 939', iso2: 'PR', code: 'PR', latitude: 18.25, longitude: -66.5,
   },
   {
-    name: 'Qatar', dial_code: '+974', code: 'QA', latitude: 25.5, longitude: 51.25,
+    name: 'Qatar', dial_code: '+974', iso2: 'QA', code: 'QA', latitude: 25.5, longitude: 51.25,
   },
   {
-    name: 'Réunion', dial_code: '+262', code: 'RE', latitude: -21.1, longitude: 55.6,
+    name: 'Réunion', dial_code: '+262', iso2: 'RE', code: 'RE', latitude: -21.1, longitude: 55.6,
   },
   {
-    name: 'Romania', dial_code: '+40', code: 'RO', latitude: 46, longitude: 25,
+    name: 'Romania', dial_code: '+40', iso2: 'RO', code: 'RO', latitude: 46, longitude: 25,
   },
   {
-    name: 'Russia', dial_code: '+7', code: 'RU', latitude: 60, longitude: 100,
+    name: 'Russia', dial_code: '+7', iso2: 'RU', code: 'RU', latitude: 60, longitude: 100,
   },
   {
-    name: 'Rwanda', dial_code: '+250', code: 'RW', latitude: -2, longitude: 30,
+    name: 'Rwanda', dial_code: '+250', iso2: 'RW', code: 'RW', latitude: -2, longitude: 30,
   },
   {
-    name: 'Saint Helena, Ascension and Tristan Da Cunha', dial_code: '+290', code: 'SH', latitude: -15.9333, longitude: -5.7,
+    name: 'Saint Helena, Ascension and Tristan Da Cunha', dial_code: '+290', iso2: 'SH', code: 'SH', latitude: -15.9333, longitude: -5.7,
   },
   {
-    name: 'Saint Kitts and Nevis', dial_code: '+1 869', code: 'KN', latitude: 17.3333, longitude: -62.75,
+    name: 'Saint Kitts and Nevis', dial_code: '+1 869', iso2: 'KN', code: 'KN', latitude: 17.3333, longitude: -62.75,
   },
   {
-    name: 'Saint Lucia', dial_code: '+1 758', code: 'LC', latitude: 13.8833, longitude: -61.1333,
+    name: 'Saint Lucia', dial_code: '+1 758', iso2: 'LC', code: 'LC', latitude: 13.8833, longitude: -61.1333,
   },
   {
-    name: 'Saint Pierre and Miquelon', dial_code: '+508', code: 'PM', latitude: 46.8333, longitude: -56.3333,
+    name: 'Saint Pierre and Miquelon', dial_code: '+508', iso2: 'PM', code: 'PM', latitude: 46.8333, longitude: -56.3333,
   },
   {
-    name: 'Saint Vincent and the Grenadines', dial_code: '+1 784', code: 'VC', latitude: 13.25, longitude: -61.2,
+    name: 'Saint Vincent and the Grenadines', dial_code: '+1 784', iso2: 'VC', code: 'VC', latitude: 13.25, longitude: -61.2,
   },
   {
-    name: 'Samoa', dial_code: '+685', code: 'WS', latitude: -13.5833, longitude: -172.3333,
+    name: 'Samoa', dial_code: '+685', iso2: 'WS', code: 'WS', latitude: -13.5833, longitude: -172.3333,
   },
   {
-    name: 'San Marino', dial_code: '+378', code: 'SM', latitude: 43.7667, longitude: 12.4167,
+    name: 'San Marino', dial_code: '+378', iso2: 'SM', code: 'SM', latitude: 43.7667, longitude: 12.4167,
   },
   {
-    name: 'Sao Tome and Principe', dial_code: '+239', code: 'ST', latitude: 1, longitude: 7,
+    name: 'Sao Tome and Principe', dial_code: '+239', iso2: 'ST', code: 'ST', latitude: 1, longitude: 7,
   },
   {
-    name: 'Saudi Arabia', dial_code: '+966', code: 'SA', latitude: 25, longitude: 45,
+    name: 'Saudi Arabia', dial_code: '+966', iso2: 'SA', code: 'SA', latitude: 25, longitude: 45,
   },
   {
-    name: 'Senegal', dial_code: '+221', code: 'SN', latitude: 14, longitude: -14,
+    name: 'Senegal', dial_code: '+221', iso2: 'SN', code: 'SN', latitude: 14, longitude: -14,
   },
   {
-    name: 'Serbia', dial_code: '+381', code: 'RS', latitude: 44, longitude: 21,
+    name: 'Serbia', dial_code: '+381', iso2: 'RS', code: 'RS', latitude: 44, longitude: 21,
   },
   {
-    name: 'Seychelles', dial_code: '+248', code: 'SC', latitude: -4.5833, longitude: 55.6667,
+    name: 'Seychelles', dial_code: '+248', iso2: 'SC', code: 'SC', latitude: -4.5833, longitude: 55.6667,
   },
   {
-    name: 'Sierra Leone', dial_code: '+232', code: 'SL', latitude: 8.5, longitude: -11.5,
+    name: 'Sierra Leone', dial_code: '+232', iso2: 'SL', code: 'SL', latitude: 8.5, longitude: -11.5,
   },
   {
-    name: 'Singapore', dial_code: '+65', code: 'SG', latitude: 1.3667, longitude: 103.8,
+    name: 'Singapore', dial_code: '+65', iso2: 'SG', code: 'SG', latitude: 1.3667, longitude: 103.8,
   },
   {
-    name: 'Slovakia', dial_code: '+421', code: 'SK', latitude: 48.6667, longitude: 19.5,
+    name: 'Slovakia', dial_code: '+421', iso2: 'SK', code: 'SK', latitude: 48.6667, longitude: 19.5,
   },
   {
-    name: 'Slovenia', dial_code: '+386', code: 'SI', latitude: 46, longitude: 15,
+    name: 'Slovenia', dial_code: '+386', iso2: 'SI', code: 'SI', latitude: 46, longitude: 15,
   },
   {
-    name: 'Solomon Islands', dial_code: '+677', code: 'SB', latitude: -8, longitude: 159,
+    name: 'Solomon Islands', dial_code: '+677', iso2: 'SB', code: 'SB', latitude: -8, longitude: 159,
   },
   {
-    name: 'Somalia', dial_code: '+252', code: 'SO', latitude: 10, longitude: 49,
+    name: 'Somalia', dial_code: '+252', iso2: 'SO', code: 'SO', latitude: 10, longitude: 49,
   },
   {
-    name: 'South Africa', dial_code: '+27', code: 'ZA', latitude: -29, longitude: 24,
+    name: 'South Africa', dial_code: '+27', iso2: 'ZA', code: 'ZA', latitude: -29, longitude: 24,
   },
   {
-    name: 'South Georgia and the South Sandwich Islands', dial_code: '+500', code: 'GS', latitude: -54.5, longitude: -37,
+    name: 'South Georgia and the South Sandwich Islands', dial_code: '+500', iso2: 'GS', code: 'GS', latitude: -54.5, longitude: -37,
   }, {
-    name: 'Spain', dial_code: '+34', code: 'ES', latitude: 40, longitude: -4,
+    name: 'Spain', dial_code: '+34', iso2: 'ES', code: 'ES', latitude: 40, longitude: -4,
   },
   {
-    name: 'Sri Lanka', dial_code: '+94', code: 'LK', latitude: 7, longitude: 81,
+    name: 'Sri Lanka', dial_code: '+94', iso2: 'LK', code: 'LK', latitude: 7, longitude: 81,
   },
   {
-    name: 'Sudan', dial_code: '+249', code: 'SD', latitude: 15, longitude: 30,
+    name: 'Sudan', dial_code: '+249', iso2: 'SD', code: 'SD', latitude: 15, longitude: 30,
   },
   {
-    name: 'Suriname', dial_code: '+597', code: 'SR', latitude: 4, longitude: -56,
+    name: 'Suriname', dial_code: '+597', iso2: 'SR', code: 'SR', latitude: 4, longitude: -56,
   },
   {
-    name: 'Svalbard and Jan Mayen', dial_code: '+47', code: 'SJ', latitude: 78, longitude: 20,
+    name: 'Svalbard and Jan Mayen', dial_code: '+47', iso2: 'SJ', code: 'SJ', latitude: 78, longitude: 20,
   },
   {
-    name: 'Swaziland', dial_code: '+268', code: 'SZ', latitude: -26.5, longitude: 31.5,
+    name: 'Swaziland', dial_code: '+268', iso2: 'SZ', code: 'SZ', latitude: -26.5, longitude: 31.5,
   },
   {
-    name: 'Sweden', dial_code: '+46', code: 'SE', latitude: 62, longitude: 15,
+    name: 'Sweden', dial_code: '+46', iso2: 'SE', code: 'SE', latitude: 62, longitude: 15,
   },
   {
-    name: 'Switzerland', dial_code: '+41', code: 'CH', latitude: 47, longitude: 8,
+    name: 'Switzerland', dial_code: '+41', iso2: 'CH', code: 'CH', latitude: 47, longitude: 8,
   },
   {
-    name: 'Syria', dial_code: '+963', code: 'SY', latitude: 35, longitude: 38,
+    name: 'Syria', dial_code: '+963', iso2: 'SY', code: 'SY', latitude: 35, longitude: 38,
   },
   {
-    name: 'Taiwan', dial_code: '+886', code: 'TW', latitude: 23.5, longitude: 121,
+    name: 'Taiwan', dial_code: '+886', iso2: 'TW', code: 'TW', latitude: 23.5, longitude: 121,
   },
   {
-    name: 'Tajikistan', dial_code: '+992', code: 'TJ', latitude: 39, longitude: 71,
+    name: 'Tajikistan', dial_code: '+992', iso2: 'TJ', code: 'TJ', latitude: 39, longitude: 71,
   },
   {
-    name: 'Tanzania, United Republic of', dial_code: '+255', code: 'TZ', latitude: -6, longitude: 35,
+    name: 'Tanzania, United Republic of', dial_code: '+255', iso2: 'TZ', code: 'TZ', latitude: -6, longitude: 35,
   },
   {
-    name: 'Thailand', dial_code: '+66', code: 'TH', latitude: 15, longitude: 100,
+    name: 'Thailand', dial_code: '+66', iso2: 'TH', code: 'TH', latitude: 15, longitude: 100,
   },
   {
-    name: 'Timor-Leste', dial_code: '+670', code: 'TL', latitude: -8.55, longitude: 125.5167,
+    name: 'Timor-Leste', dial_code: '+670', iso2: 'TL', code: 'TL', latitude: -8.55, longitude: 125.5167,
   },
   {
-    name: 'Togo', dial_code: '+228', code: 'TG', latitude: 8, longitude: 1.1667,
+    name: 'Togo', dial_code: '+228', iso2: 'TG', code: 'TG', latitude: 8, longitude: 1.1667,
   },
   {
-    name: 'Tokelau', dial_code: '+690', code: 'TK', latitude: -9, longitude: -172,
+    name: 'Tokelau', dial_code: '+690', iso2: 'TK', code: 'TK', latitude: -9, longitude: -172,
   },
   {
-    name: 'Tonga', dial_code: '+676', code: 'TO', latitude: -20, longitude: -175,
+    name: 'Tonga', dial_code: '+676', iso2: 'TO', code: 'TO', latitude: -20, longitude: -175,
   },
   {
-    name: 'Trinidad and Tobago', dial_code: '+1 868', code: 'TT', latitude: 11, longitude: -61,
+    name: 'Trinidad and Tobago', dial_code: '+1 868', iso2: 'TT', code: 'TT', latitude: 11, longitude: -61,
   },
   {
-    name: 'Tunisia', dial_code: '+216', code: 'TN', latitude: 34, longitude: 9,
+    name: 'Tunisia', dial_code: '+216', iso2: 'TN', code: 'TN', latitude: 34, longitude: 9,
   },
   {
-    name: 'Turkey', dial_code: '+90', code: 'TR', latitude: 39, longitude: 35,
+    name: 'Turkey', dial_code: '+90', iso2: 'TR', code: 'TR', latitude: 39, longitude: 35,
   },
   {
-    name: 'Turkmenistan', dial_code: '+993', code: 'TM', latitude: 40, longitude: 60,
+    name: 'Turkmenistan', dial_code: '+993', iso2: 'TM', code: 'TM', latitude: 40, longitude: 60,
   },
   {
-    name: 'Turks and Caicos Islands', dial_code: '+1 649', code: 'TC', latitude: 21.75, longitude: -71.5833,
+    name: 'Turks and Caicos Islands', dial_code: '+1 649', iso2: 'TC', code: 'TC', latitude: 21.75, longitude: -71.5833,
   },
   {
-    name: 'Tuvalu', dial_code: '+688', code: 'TV', latitude: -8, longitude: 178,
+    name: 'Tuvalu', dial_code: '+688', iso2: 'TV', code: 'TV', latitude: -8, longitude: 178,
   },
   {
-    name: 'Uganda', dial_code: '+256', code: 'UG', latitude: 1, longitude: 32,
+    name: 'Uganda', dial_code: '+256', iso2: 'UG', code: 'UG', latitude: 1, longitude: 32,
   },
   {
-    name: 'Ukraine', dial_code: '+380', code: 'UA', latitude: 49, longitude: 32,
+    name: 'Ukraine', dial_code: '+380', iso2: 'UA', code: 'UA', latitude: 49, longitude: 32,
   },
   {
-    name: 'United Arab Emirates', dial_code: '+971', code: 'AE', latitude: 24, longitude: 54,
+    name: 'United Arab Emirates', dial_code: '+971', iso2: 'AE', code: 'AE', latitude: 24, longitude: 54,
   },
   {
-    name: 'United Kingdom', dial_code: '+44', code: 'GB', latitude: 54, longitude: -2,
+    name: 'United Kingdom', dial_code: '+44', iso2: 'GB', code: 'GB', latitude: 54, longitude: -2,
   }, {
-    name: 'United States', dial_code: '+1', code: 'US', latitude: 38, longitude: -97,
+    name: 'United States', dial_code: '+1', iso2: 'US', code: 'US', latitude: 38, longitude: -97,
   },
   {
-    name: 'United States Minor Outlying Islands', dial_code: '+1581', code: 'UM', latitude: 19.2833, longitude: 166.6,
+    name: 'United States Minor Outlying Islands', dial_code: '+1581', iso2: 'UM', code: 'UM', latitude: 19.2833, longitude: 166.6,
   },
   {
-    name: 'Uruguay', dial_code: '+598', code: 'UY', latitude: -33, longitude: -56,
+    name: 'Uruguay', dial_code: '+598', iso2: 'UY', code: 'UY', latitude: -33, longitude: -56,
   },
   {
-    name: 'Uzbekistan', dial_code: '+998', code: 'UZ', latitude: 41, longitude: 64,
+    name: 'Uzbekistan', dial_code: '+998', iso2: 'UZ', code: 'UZ', latitude: 41, longitude: 64,
   },
   {
-    name: 'Vanuatu', dial_code: '+678', code: 'VU', latitude: -16, longitude: 167,
+    name: 'Vanuatu', dial_code: '+678', iso2: 'VU', code: 'VU', latitude: -16, longitude: 167,
   },
   {
-    name: 'Venezuela, Bolivarian Republic of', dial_code: '+58', code: 'VE', latitude: 8, longitude: -66,
+    name: 'Venezuela, Bolivarian Republic of', dial_code: '+58', iso2: 'VE', code: 'VE', latitude: 8, longitude: -66,
   },
   {
-    name: 'Vietnam', dial_code: '+84', code: 'VN', latitude: 16, longitude: 106,
+    name: 'Vietnam', dial_code: '+84', iso2: 'VN', code: 'VN', latitude: 16, longitude: 106,
   },
   {
-    name: 'Virgin Islands, British', dial_code: '+1 284', code: 'VG', latitude: 18.5, longitude: -64.5,
+    name: 'Virgin Islands, British', dial_code: '+1 284', iso2: 'VG', code: 'VG', latitude: 18.5, longitude: -64.5,
   },
   {
-    name: 'Virgin Islands, U.S.', dial_code: '+1 340', code: 'VI', latitude: 18.3333, longitude: -64.8333,
+    name: 'Virgin Islands, U.S.', dial_code: '+1 340', iso2: 'VI', code: 'VI', latitude: 18.3333, longitude: -64.8333,
   },
   {
-    name: 'Wallis and Futuna', dial_code: '+681', code: 'WF', latitude: -13.3, longitude: -176.2,
+    name: 'Wallis and Futuna', dial_code: '+681', iso2: 'WF', code: 'WF', latitude: -13.3, longitude: -176.2,
   },
   {
-    name: 'Western Sahara', dial_code: '+732', code: 'EH', latitude: 24.5, longitude: -13,
+    name: 'Western Sahara', dial_code: '+732', iso2: 'EH', code: 'EH', latitude: 24.5, longitude: -13,
   },
   {
-    name: 'Yemen', dial_code: '+967', code: 'YE', latitude: 15, longitude: 48,
+    name: 'Yemen', dial_code: '+967', iso2: 'YE', code: 'YE', latitude: 15, longitude: 48,
   },
   {
-    name: 'Zambia', dial_code: '+260', code: 'ZM', latitude: -15, longitude: 30,
+    name: 'Zambia', dial_code: '+260', iso2: 'ZM', code: 'ZM', latitude: -15, longitude: 30,
   },
   {
-    name: 'Zimbabwe', dial_code: '+263', code: 'ZW', latitude: -20, longitude: 30,
+    name: 'Zimbabwe', dial_code: '+263', iso2: 'ZW', code: 'ZW', latitude: -20, longitude: 30,
   },
 ];
 

--- a/model/countriesAndState.js
+++ b/model/countriesAndState.js
@@ -4752,7 +4752,7 @@ const CountriesState = [
     ],
   },
   {
-    name: 'Congo The Democratic Republic Of The',
+    name: 'Congo',
     iso3: 'COD',
     iso2: 'CD',
     phone_code: '243',
@@ -4956,7 +4956,7 @@ const CountriesState = [
     ],
   },
   {
-    name: 'Cote D\'Ivoire (Ivory Coast)',
+    name: 'Ivory Coast',
     iso3: 'CIV',
     iso2: 'CI',
     phone_code: '225',
@@ -11154,7 +11154,7 @@ const CountriesState = [
     ],
   },
   {
-    name: 'Korea North',
+    name: 'North Korea',
     iso3: 'PRK',
     iso2: 'KP',
     phone_code: '850',
@@ -11219,7 +11219,7 @@ const CountriesState = [
     ],
   },
   {
-    name: 'Korea South',
+    name: 'South Korea',
     iso3: 'KOR',
     iso2: 'KR',
     phone_code: '82',

--- a/model/countriesAndUnicodes.js
+++ b/model/countriesAndUnicodes.js
@@ -1561,7 +1561,7 @@ const CountriesAndUnicodes = [
   },
   {
     Iso2: 'CG',
-    Name: 'Republic of the Congo',
+    Name: 'Congo',
     Iso3: 'COG',
     Unicode: '🇨🇬',
     Dial: '242',

--- a/package-lock.json
+++ b/package-lock.json
@@ -1084,6 +1084,12 @@
       "resolved": "https://registry.npmjs.org/@jsdevtools/ono/-/ono-7.1.3.tgz",
       "integrity": "sha512-4JQNk+3mVzK3xh2rqd6RB4J46qUR19azEHBneZyTZM+c456qOrbbM/5xcR8huNCCcbVt7+UmizG6GuUvPvKUYg=="
     },
+    "@sindresorhus/is": {
+      "version": "0.14.0",
+      "resolved": "https://registry.npmjs.org/@sindresorhus/is/-/is-0.14.0.tgz",
+      "integrity": "sha512-9NET910DNaIPngYnLLPeg+Ogzqsi9uM4mSboU5y6p8S5DzMTVEsJZrawi+BoDNUVBa2DhJqQYUFvMDfgU062LQ==",
+      "dev": true
+    },
     "@sinonjs/commons": {
       "version": "1.8.1",
       "resolved": "https://registry.npmjs.org/@sinonjs/commons/-/commons-1.8.1.tgz",
@@ -1091,6 +1097,15 @@
       "dev": true,
       "requires": {
         "type-detect": "4.0.8"
+      }
+    },
+    "@szmarczak/http-timer": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/@szmarczak/http-timer/-/http-timer-1.1.2.tgz",
+      "integrity": "sha512-XIB2XbzHTN6ieIjfIMV9hlVcfPU26s2vafYWQcZHWXHOxiaRZYEDKEwdl129Zyg50+foYV2jCgtrqSA6qNuNSA==",
+      "dev": true,
+      "requires": {
+        "defer-to-connect": "^1.0.1"
       }
     },
     "@types/babel__core": {
@@ -1333,6 +1348,55 @@
       "integrity": "sha1-SlKCrBZHKek2Gbz9OtFR+BfOkfU=",
       "dev": true,
       "optional": true
+    },
+    "ansi-align": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/ansi-align/-/ansi-align-3.0.1.tgz",
+      "integrity": "sha512-IOfwwBF5iczOjp/WeY4YxyjqAFMQoZufdQWDd19SEExbVLNXqvpzSJ/M7Za4/sCPmQ0+GRquoA7bGcINcxew6w==",
+      "dev": true,
+      "requires": {
+        "string-width": "^4.1.0"
+      },
+      "dependencies": {
+        "ansi-regex": {
+          "version": "5.0.1",
+          "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.1.tgz",
+          "integrity": "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==",
+          "dev": true
+        },
+        "emoji-regex": {
+          "version": "8.0.0",
+          "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-8.0.0.tgz",
+          "integrity": "sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A==",
+          "dev": true
+        },
+        "is-fullwidth-code-point": {
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-3.0.0.tgz",
+          "integrity": "sha512-zymm5+u+sCsSWyD9qNaejV3DFvhCKclKdizYaJUuHA83RLjb7nSuGnddCHGv0hk+KY7BMAlsWeK4Ueg6EV6XQg==",
+          "dev": true
+        },
+        "string-width": {
+          "version": "4.2.3",
+          "resolved": "https://registry.npmjs.org/string-width/-/string-width-4.2.3.tgz",
+          "integrity": "sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==",
+          "dev": true,
+          "requires": {
+            "emoji-regex": "^8.0.0",
+            "is-fullwidth-code-point": "^3.0.0",
+            "strip-ansi": "^6.0.1"
+          }
+        },
+        "strip-ansi": {
+          "version": "6.0.1",
+          "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.1.tgz",
+          "integrity": "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==",
+          "dev": true,
+          "requires": {
+            "ansi-regex": "^5.0.1"
+          }
+        }
+      }
     },
     "ansi-colors": {
       "version": "4.1.1",
@@ -1807,6 +1871,95 @@
         }
       }
     },
+    "boxen": {
+      "version": "5.1.2",
+      "resolved": "https://registry.npmjs.org/boxen/-/boxen-5.1.2.tgz",
+      "integrity": "sha512-9gYgQKXx+1nP8mP7CzFyaUARhg7D3n1dF/FnErWmu9l6JvGpNUN278h0aSb+QjoiKSWG+iZ3uHrcqk0qrY9RQQ==",
+      "dev": true,
+      "requires": {
+        "ansi-align": "^3.0.0",
+        "camelcase": "^6.2.0",
+        "chalk": "^4.1.0",
+        "cli-boxes": "^2.2.1",
+        "string-width": "^4.2.2",
+        "type-fest": "^0.20.2",
+        "widest-line": "^3.1.0",
+        "wrap-ansi": "^7.0.0"
+      },
+      "dependencies": {
+        "ansi-regex": {
+          "version": "5.0.1",
+          "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.1.tgz",
+          "integrity": "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==",
+          "dev": true
+        },
+        "camelcase": {
+          "version": "6.2.1",
+          "resolved": "https://registry.npmjs.org/camelcase/-/camelcase-6.2.1.tgz",
+          "integrity": "sha512-tVI4q5jjFV5CavAU8DXfza/TJcZutVKo/5Foskmsqcm0MsL91moHvwiGNnqaa2o6PF/7yT5ikDRcVcl8Rj6LCA==",
+          "dev": true
+        },
+        "chalk": {
+          "version": "4.1.2",
+          "resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.2.tgz",
+          "integrity": "sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA==",
+          "dev": true,
+          "requires": {
+            "ansi-styles": "^4.1.0",
+            "supports-color": "^7.1.0"
+          }
+        },
+        "emoji-regex": {
+          "version": "8.0.0",
+          "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-8.0.0.tgz",
+          "integrity": "sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A==",
+          "dev": true
+        },
+        "is-fullwidth-code-point": {
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-3.0.0.tgz",
+          "integrity": "sha512-zymm5+u+sCsSWyD9qNaejV3DFvhCKclKdizYaJUuHA83RLjb7nSuGnddCHGv0hk+KY7BMAlsWeK4Ueg6EV6XQg==",
+          "dev": true
+        },
+        "string-width": {
+          "version": "4.2.3",
+          "resolved": "https://registry.npmjs.org/string-width/-/string-width-4.2.3.tgz",
+          "integrity": "sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==",
+          "dev": true,
+          "requires": {
+            "emoji-regex": "^8.0.0",
+            "is-fullwidth-code-point": "^3.0.0",
+            "strip-ansi": "^6.0.1"
+          }
+        },
+        "strip-ansi": {
+          "version": "6.0.1",
+          "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.1.tgz",
+          "integrity": "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==",
+          "dev": true,
+          "requires": {
+            "ansi-regex": "^5.0.1"
+          }
+        },
+        "type-fest": {
+          "version": "0.20.2",
+          "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-0.20.2.tgz",
+          "integrity": "sha512-Ne+eE4r0/iWnpAxD852z3A+N0Bt5RN//NjJwRd2VFHEmrywxf5vsZlh4R6lixl6B+wz/8d+maTSAkN1FIkI3LQ==",
+          "dev": true
+        },
+        "wrap-ansi": {
+          "version": "7.0.0",
+          "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-7.0.0.tgz",
+          "integrity": "sha512-YVGIj2kamLSTxw6NsZjoBxfSwsn0ycdesmc4p+Q21c5zPuZ1pl+NfxVdxPtdHvmNVOQ6XSYG4AUtyt/Fi7D16Q==",
+          "dev": true,
+          "requires": {
+            "ansi-styles": "^4.0.0",
+            "string-width": "^4.1.0",
+            "strip-ansi": "^6.0.0"
+          }
+        }
+      }
+    },
     "brace-expansion": {
       "version": "1.1.11",
       "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.11.tgz",
@@ -1909,6 +2062,38 @@
         "to-object-path": "^0.3.0",
         "union-value": "^1.0.0",
         "unset-value": "^1.0.0"
+      }
+    },
+    "cacheable-request": {
+      "version": "6.1.0",
+      "resolved": "https://registry.npmjs.org/cacheable-request/-/cacheable-request-6.1.0.tgz",
+      "integrity": "sha512-Oj3cAGPCqOZX7Rz64Uny2GYAZNliQSqfbePrgAQ1wKAihYmCUnraBtJtKcGR4xz7wF+LoJC+ssFZvv5BgF9Igg==",
+      "dev": true,
+      "requires": {
+        "clone-response": "^1.0.2",
+        "get-stream": "^5.1.0",
+        "http-cache-semantics": "^4.0.0",
+        "keyv": "^3.0.0",
+        "lowercase-keys": "^2.0.0",
+        "normalize-url": "^4.1.0",
+        "responselike": "^1.0.2"
+      },
+      "dependencies": {
+        "get-stream": {
+          "version": "5.2.0",
+          "resolved": "https://registry.npmjs.org/get-stream/-/get-stream-5.2.0.tgz",
+          "integrity": "sha512-nBF+F1rAZVCu/p7rjzgA+Yb4lfYXrpl7a6VmJrU8wF9I1CKvP/QwPNZHnOlwbTkY6dvtFIzFMSyQXbLoTQPRpA==",
+          "dev": true,
+          "requires": {
+            "pump": "^3.0.0"
+          }
+        },
+        "lowercase-keys": {
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/lowercase-keys/-/lowercase-keys-2.0.0.tgz",
+          "integrity": "sha512-tqNXrS78oMOE73NMxK4EMLQsQowWf8jKooH9g7xPavRT706R6bkQJ6DY2Te7QukaZsulxa30wQ7bk0pm4XiHmA==",
+          "dev": true
+        }
       }
     },
     "cachedir": {
@@ -2156,6 +2341,12 @@
       "integrity": "sha512-4diC9HaTE+KRAMWhDhrGOECgWZxoevMc5TlkObMqNSsVU62PYzXZ/SMTjzyGAFF1YusgxGcSWTEXBhp0CPwQ1A==",
       "dev": true
     },
+    "cli-boxes": {
+      "version": "2.2.1",
+      "resolved": "https://registry.npmjs.org/cli-boxes/-/cli-boxes-2.2.1.tgz",
+      "integrity": "sha512-y4coMcylgSCdVinjiDBuR8PCC2bLjyGTwEmPb9NHR/QaNU6EUOXcTY/s6VjGMD6ENSEaeQYHCY0GNGS5jfMwPw==",
+      "dev": true
+    },
     "cli-color": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/cli-color/-/cli-color-2.0.0.tgz",
@@ -2243,6 +2434,15 @@
       "resolved": "https://registry.npmjs.org/clone/-/clone-1.0.4.tgz",
       "integrity": "sha1-2jCcwmPfFZlMaIypAheco8fNfH4=",
       "dev": true
+    },
+    "clone-response": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/clone-response/-/clone-response-1.0.2.tgz",
+      "integrity": "sha1-0dyXOSAxTfZ/vrlCI7TuNQI56Ws=",
+      "dev": true,
+      "requires": {
+        "mimic-response": "^1.0.0"
+      }
     },
     "co": {
       "version": "4.6.0",
@@ -2370,6 +2570,20 @@
       "version": "0.0.1",
       "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
       "integrity": "sha1-2Klr13/Wjfd5OnMDajug1UBdR3s="
+    },
+    "configstore": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/configstore/-/configstore-5.0.1.tgz",
+      "integrity": "sha512-aMKprgk5YhBNyH25hj8wGt2+D52Sw1DRRIzqBwLp2Ya9mFmY8KPvvtvmna8SxVR9JMZ4kzMD68N22vlaRpkeFA==",
+      "dev": true,
+      "requires": {
+        "dot-prop": "^5.2.0",
+        "graceful-fs": "^4.1.2",
+        "make-dir": "^3.0.0",
+        "unique-string": "^2.0.0",
+        "write-file-atomic": "^3.0.0",
+        "xdg-basedir": "^4.0.0"
+      }
     },
     "confusing-browser-globals": {
       "version": "1.0.9",
@@ -2507,6 +2721,12 @@
       "version": "0.0.2",
       "resolved": "https://registry.npmjs.org/crypt/-/crypt-0.0.2.tgz",
       "integrity": "sha1-iNf/fsDfuG9xPch7u0LQRNPmxBs=",
+      "dev": true
+    },
+    "crypto-random-string": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/crypto-random-string/-/crypto-random-string-2.0.0.tgz",
+      "integrity": "sha512-v1plID3y9r/lPhviJ1wrXpLeyUIGAZ2SHNYTEapm7/8A9nLPoyvVp3RK/EPFqn5kEznyWgYZNsRtYYIWbuG8KA==",
       "dev": true
     },
     "cssom": {
@@ -2731,6 +2951,15 @@
       "integrity": "sha1-6zkTMzRYd1y4TNGh+uBiEGu4dUU=",
       "dev": true
     },
+    "decompress-response": {
+      "version": "3.3.0",
+      "resolved": "https://registry.npmjs.org/decompress-response/-/decompress-response-3.3.0.tgz",
+      "integrity": "sha1-gKTdMjdIOEv6JICDYirt7Jgq3/M=",
+      "dev": true,
+      "requires": {
+        "mimic-response": "^1.0.0"
+      }
+    },
     "dedent": {
       "version": "0.7.0",
       "resolved": "https://registry.npmjs.org/dedent/-/dedent-0.7.0.tgz",
@@ -2750,6 +2979,12 @@
       "version": "0.2.2",
       "resolved": "https://registry.npmjs.org/deep-equal/-/deep-equal-0.2.2.tgz",
       "integrity": "sha1-hLdFiW80xoTpjyzg5Cq69Du6AX0=",
+      "dev": true
+    },
+    "deep-extend": {
+      "version": "0.6.0",
+      "resolved": "https://registry.npmjs.org/deep-extend/-/deep-extend-0.6.0.tgz",
+      "integrity": "sha512-LOHxIOaPYdHlJRtCQfDIVZtfw/ufM8+rVj649RIHzcm/vGwQRXFt6OPqIFWsm2XEMrNIEtWR64sY1LEKD2vAOA==",
       "dev": true
     },
     "deep-is": {
@@ -2781,6 +3016,12 @@
       "requires": {
         "clone": "^1.0.2"
       }
+    },
+    "defer-to-connect": {
+      "version": "1.1.3",
+      "resolved": "https://registry.npmjs.org/defer-to-connect/-/defer-to-connect-1.1.3.tgz",
+      "integrity": "sha512-0ISdNousHvZT2EiFlZeZAHBUvSxmKswVCEf8hW7KWgG4a8MVEu/3Vb6uWYozkjylyCxe0JBIiRB1jV45S70WVQ==",
+      "dev": true
     },
     "define-properties": {
       "version": "1.1.3",
@@ -2895,10 +3136,25 @@
         "webidl-conversions": "^4.0.2"
       }
     },
+    "dot-prop": {
+      "version": "5.3.0",
+      "resolved": "https://registry.npmjs.org/dot-prop/-/dot-prop-5.3.0.tgz",
+      "integrity": "sha512-QM8q3zDe58hqUqjraQOmzZ1LIH9SWQJTlEKCH4kJ2oQvLZk7RbQXvtDM2XEq3fwkV9CCvvH4LA0AV+ogFsBM2Q==",
+      "dev": true,
+      "requires": {
+        "is-obj": "^2.0.0"
+      }
+    },
     "dotenv": {
       "version": "8.2.0",
       "resolved": "https://registry.npmjs.org/dotenv/-/dotenv-8.2.0.tgz",
       "integrity": "sha512-8sJ78ElpbDJBHNeBzUbUVLsqKdccaa/BXF1uPTw3GrvQTBgrQrtObr2mUrE38vzYd8cEv+m/JBfDLioYcfXoaw=="
+    },
+    "duplexer3": {
+      "version": "0.1.4",
+      "resolved": "https://registry.npmjs.org/duplexer3/-/duplexer3-0.1.4.tgz",
+      "integrity": "sha1-7gHdHKwO08vH/b6jfcCo8c4ALOI=",
+      "dev": true
     },
     "ecc-jsbn": {
       "version": "0.1.2",
@@ -3120,6 +3376,12 @@
         "es6-iterator": "^2.0.3",
         "es6-symbol": "^3.1.1"
       }
+    },
+    "escape-goat": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/escape-goat/-/escape-goat-2.1.1.tgz",
+      "integrity": "sha512-8/uIhbG12Csjy2JEW7D9pHbreaVaS/OpN3ycnyvElTdwM5n6GY6W6e2IPemfvGZeUMqZ9A/3GqIZMgKnBhAw/Q==",
+      "dev": true
     },
     "escape-html": {
       "version": "1.0.3",
@@ -4302,6 +4564,25 @@
         "type-fest": "^0.8.1"
       }
     },
+    "got": {
+      "version": "9.6.0",
+      "resolved": "https://registry.npmjs.org/got/-/got-9.6.0.tgz",
+      "integrity": "sha512-R7eWptXuGYxwijs0eV+v3o6+XH1IqVK8dJOEecQfTmkncw9AV4dcw/Dhxi8MdlqPthxxpZyizMzyg8RTmEsG+Q==",
+      "dev": true,
+      "requires": {
+        "@sindresorhus/is": "^0.14.0",
+        "@szmarczak/http-timer": "^1.1.2",
+        "cacheable-request": "^6.0.0",
+        "decompress-response": "^3.3.0",
+        "duplexer3": "^0.1.4",
+        "get-stream": "^4.1.0",
+        "lowercase-keys": "^1.0.1",
+        "mimic-response": "^1.0.1",
+        "p-cancelable": "^1.0.0",
+        "to-readable-stream": "^1.0.0",
+        "url-parse-lax": "^3.0.0"
+      }
+    },
     "graceful-fs": {
       "version": "4.2.4",
       "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.2.4.tgz",
@@ -4402,6 +4683,12 @@
         }
       }
     },
+    "has-yarn": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/has-yarn/-/has-yarn-2.1.0.tgz",
+      "integrity": "sha512-UqBRqi4ju7T+TqGNdqAO0PaSVGsDGJUBQvk9eUWNGRY1CFGDzYhLWoM7JQEemnlvVcv/YEmc2wNW8BC24EnUsw==",
+      "dev": true
+    },
     "hasha": {
       "version": "5.2.0",
       "resolved": "https://registry.npmjs.org/hasha/-/hasha-5.2.0.tgz",
@@ -4471,6 +4758,12 @@
       "integrity": "sha512-H2iMtd0I4Mt5eYiapRdIDjp+XzelXQ0tFE4JS7YFwFevXXMmOp9myNrUvCg0D6ws8iqkRPBfKHgbwig1SmlLfg==",
       "dev": true
     },
+    "http-cache-semantics": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/http-cache-semantics/-/http-cache-semantics-4.1.0.tgz",
+      "integrity": "sha512-carPklcUh7ROWRK7Cv27RPtdhYhUsela/ue5/jKzjegVvXDqM2ILE9Q2BGn9JZJh1g87cp56su/FgQSzcWS8cQ==",
+      "dev": true
+    },
     "http-errors": {
       "version": "1.6.3",
       "resolved": "https://registry.npmjs.org/http-errors/-/http-errors-1.6.3.tgz",
@@ -4526,6 +4819,12 @@
       "integrity": "sha512-cyFDKrqc/YdcWFniJhzI42+AzS+gNwmUzOSFcRCQYwySuBBBy/KjuxWLZ/FHEH6Moq1NizMOBWyTcv8O4OZIMg==",
       "dev": true
     },
+    "ignore-by-default": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/ignore-by-default/-/ignore-by-default-1.0.1.tgz",
+      "integrity": "sha1-SMptcvbGo68Aqa1K5odr44ieKwk=",
+      "dev": true
+    },
     "import-fresh": {
       "version": "3.2.1",
       "resolved": "https://registry.npmjs.org/import-fresh/-/import-fresh-3.2.1.tgz",
@@ -4543,6 +4842,12 @@
           "dev": true
         }
       }
+    },
+    "import-lazy": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/import-lazy/-/import-lazy-2.1.0.tgz",
+      "integrity": "sha1-BWmOPUXIjo1+nZLLBYTnfwlvPkM=",
+      "dev": true
     },
     "import-local": {
       "version": "3.0.2",
@@ -4968,6 +5273,33 @@
         "is-extglob": "^2.1.1"
       }
     },
+    "is-installed-globally": {
+      "version": "0.4.0",
+      "resolved": "https://registry.npmjs.org/is-installed-globally/-/is-installed-globally-0.4.0.tgz",
+      "integrity": "sha512-iwGqO3J21aaSkC7jWnHP/difazwS7SFeIqxv6wEtLU8Y5KlzFTjyqcSIT0d8s4+dDhKytsk9PJZ2BkS5eZwQRQ==",
+      "dev": true,
+      "requires": {
+        "global-dirs": "^3.0.0",
+        "is-path-inside": "^3.0.2"
+      },
+      "dependencies": {
+        "global-dirs": {
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/global-dirs/-/global-dirs-3.0.0.tgz",
+          "integrity": "sha512-v8ho2DS5RiCjftj1nD9NmnfaOzTdud7RRnVd9kFNOjqZbISlx5DQ+OrTkywgd0dIt7oFCvKetZSHoHcP3sDdiA==",
+          "dev": true,
+          "requires": {
+            "ini": "2.0.0"
+          }
+        },
+        "ini": {
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/ini/-/ini-2.0.0.tgz",
+          "integrity": "sha512-7PnF4oN3CvZF23ADhA5wRaYEQpJ8qygSkbtTXWBeXWXmEVRXK+1ITciHWwHhsjv1TmW0MgacIv6hEi5pX5NQdA==",
+          "dev": true
+        }
+      }
+    },
     "is-ip": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/is-ip/-/is-ip-2.0.0.tgz",
@@ -4989,6 +5321,12 @@
       "integrity": "sha1-lVOxIbD6wohp2p7UWeIMdUN4hGE=",
       "dev": true
     },
+    "is-npm": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/is-npm/-/is-npm-5.0.0.tgz",
+      "integrity": "sha512-WW/rQLOazUq+ST/bCAVBp/2oMERWLsR7OrKyt052dNDk4DHcDE0/7QSXITlmi+VBcV13DfIbysG3tZJm5RfdBA==",
+      "dev": true
+    },
     "is-number": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/is-number/-/is-number-3.0.0.tgz",
@@ -5008,6 +5346,18 @@
           }
         }
       }
+    },
+    "is-obj": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/is-obj/-/is-obj-2.0.0.tgz",
+      "integrity": "sha512-drqDG3cbczxxEJRoOXcOjtdp1J/lyp1mNn0xaznRs8+muBhgQcrnbspox5X5fOw0HnMnbfDzvnEMEtqDEJEo8w==",
+      "dev": true
+    },
+    "is-path-inside": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/is-path-inside/-/is-path-inside-3.0.3.tgz",
+      "integrity": "sha512-Fd4gABb+ycGAmKou8eMftCupSir5lRxqf4aD/vd0cD2qc4HL07OjCeuHMr8Ro4CoMaeCKDB0/ECBOVWjTwUvPQ==",
+      "dev": true
     },
     "is-plain-obj": {
       "version": "1.1.0",
@@ -5093,6 +5443,12 @@
       "requires": {
         "is-docker": "^2.0.0"
       }
+    },
+    "is-yarn-global": {
+      "version": "0.3.0",
+      "resolved": "https://registry.npmjs.org/is-yarn-global/-/is-yarn-global-0.3.0.tgz",
+      "integrity": "sha512-VjSeb/lHmkoyd8ryPVIKvOCn4D1koMqY+vqyjjUfc3xyKtP4dYOxM44sZrnqQSzSds3xyOrUTLTC9LVCVgLngw==",
+      "dev": true
     },
     "isarray": {
       "version": "1.0.0",
@@ -6608,6 +6964,12 @@
       "integrity": "sha512-OYu7XEzjkCQ3C5Ps3QIZsQfNpqoJyZZA99wd9aWd05NCtC5pWOkShK2mkL6HXQR6/Cy2lbNdPlZBpuQHXE63gA==",
       "dev": true
     },
+    "json-buffer": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/json-buffer/-/json-buffer-3.0.0.tgz",
+      "integrity": "sha1-Wx85evx11ne96Lz8Dkfh+aPZqJg=",
+      "dev": true
+    },
     "json-parse-even-better-errors": {
       "version": "2.3.1",
       "resolved": "https://registry.npmjs.org/json-parse-even-better-errors/-/json-parse-even-better-errors-2.3.1.tgz",
@@ -6668,6 +7030,15 @@
         "verror": "1.10.0"
       }
     },
+    "keyv": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/keyv/-/keyv-3.1.0.tgz",
+      "integrity": "sha512-9ykJ/46SN/9KPM/sichzQ7OvXyGDYKGTaDlKMGCAlg2UK8KRy4jb0d8sFc+0Tt0YYnThq8X2RZgCg74RPxgcVA==",
+      "dev": true,
+      "requires": {
+        "json-buffer": "3.0.0"
+      }
+    },
     "kind-of": {
       "version": "6.0.3",
       "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-6.0.3.tgz",
@@ -6679,6 +7050,15 @@
       "resolved": "https://registry.npmjs.org/kleur/-/kleur-3.0.3.tgz",
       "integrity": "sha512-eTIzlVOSUR+JxdDFepEYcBMtZ9Qqdef+rnzWdRZuMbOywu5tO2w2N7rqjoANZ5k9vywhL6Br1VRjUIgTQx4E8w==",
       "dev": true
+    },
+    "latest-version": {
+      "version": "5.1.0",
+      "resolved": "https://registry.npmjs.org/latest-version/-/latest-version-5.1.0.tgz",
+      "integrity": "sha512-weT+r0kTkRQdCdYCNtkMwWXQTMEswKrFBkm4ckQOMVhhqhIMI1UT2hMj+1iigIhgSZm5gTmrRXBNoGUgaTY1xA==",
+      "dev": true,
+      "requires": {
+        "package-json": "^6.3.0"
+      }
     },
     "lcov-parse": {
       "version": "1.0.0",
@@ -6861,6 +7241,21 @@
       "integrity": "sha1-eB4YMpaqlPbU2RbcM10NF676I/g=",
       "dev": true
     },
+    "lowercase-keys": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/lowercase-keys/-/lowercase-keys-1.0.1.tgz",
+      "integrity": "sha512-G2Lj61tXDnVFFOi8VZds+SoQjtQC3dgokKdDG2mTm1tx4m50NUHBOZSBwQQHyy0V12A0JTG4icfZQH+xPyh8VA==",
+      "dev": true
+    },
+    "lru-cache": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-6.0.0.tgz",
+      "integrity": "sha512-Jo6dJ04CmSjuznwJSS3pUeWmd/H0ffTlkXXgwZi+eq1UCmqQwCh+eLsYOYCwY991i2Fah4h1BEMCx4qThGbsiA==",
+      "dev": true,
+      "requires": {
+        "yallist": "^4.0.0"
+      }
+    },
     "lru-queue": {
       "version": "0.1.0",
       "resolved": "https://registry.npmjs.org/lru-queue/-/lru-queue-0.1.0.tgz",
@@ -7008,6 +7403,12 @@
       "version": "1.2.0",
       "resolved": "https://registry.npmjs.org/mimic-fn/-/mimic-fn-1.2.0.tgz",
       "integrity": "sha512-jf84uxzwiuiIVKiOLpfYk7N46TSy8ubTonmneY9vrpHNAnp0QBt2BxWV9dO3/j+BoVAb+a5G6YDPW3M5HOdMWQ==",
+      "dev": true
+    },
+    "mimic-response": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/mimic-response/-/mimic-response-1.0.1.tgz",
+      "integrity": "sha512-j5EctnkH7amfV/q5Hgmoal1g2QHFJRraOtmx0JpIqkxhBhI/lJSl1nMpQ45hVarwNETOoWEimndZ4QK0RHxuxQ==",
       "dev": true
     },
     "minimatch": {
@@ -7330,6 +7731,137 @@
         "process-on-spawn": "^1.0.0"
       }
     },
+    "nodemon": {
+      "version": "2.0.15",
+      "resolved": "https://registry.npmjs.org/nodemon/-/nodemon-2.0.15.tgz",
+      "integrity": "sha512-gdHMNx47Gw7b3kWxJV64NI+Q5nfl0y5DgDbiVtShiwa7Z0IZ07Ll4RLFo6AjrhzMtoEZn5PDE3/c2AbVsiCkpA==",
+      "dev": true,
+      "requires": {
+        "chokidar": "^3.5.2",
+        "debug": "^3.2.7",
+        "ignore-by-default": "^1.0.1",
+        "minimatch": "^3.0.4",
+        "pstree.remy": "^1.1.8",
+        "semver": "^5.7.1",
+        "supports-color": "^5.5.0",
+        "touch": "^3.1.0",
+        "undefsafe": "^2.0.5",
+        "update-notifier": "^5.1.0"
+      },
+      "dependencies": {
+        "anymatch": {
+          "version": "3.1.2",
+          "resolved": "https://registry.npmjs.org/anymatch/-/anymatch-3.1.2.tgz",
+          "integrity": "sha512-P43ePfOAIupkguHUycrc4qJ9kz8ZiuOUijaETwX7THt0Y/GNK7v0aa8rY816xWjZ7rJdA5XdMcpVFTKMq+RvWg==",
+          "dev": true,
+          "requires": {
+            "normalize-path": "^3.0.0",
+            "picomatch": "^2.0.4"
+          }
+        },
+        "braces": {
+          "version": "3.0.2",
+          "resolved": "https://registry.npmjs.org/braces/-/braces-3.0.2.tgz",
+          "integrity": "sha512-b8um+L1RzM3WDSzvhm6gIz1yfTbBt6YTlcEKAvsmqCZZFw46z626lVj9j1yEPW33H5H+lBQpZMP1k8l+78Ha0A==",
+          "dev": true,
+          "requires": {
+            "fill-range": "^7.0.1"
+          }
+        },
+        "chokidar": {
+          "version": "3.5.2",
+          "resolved": "https://registry.npmjs.org/chokidar/-/chokidar-3.5.2.tgz",
+          "integrity": "sha512-ekGhOnNVPgT77r4K/U3GDhu+FQ2S8TnK/s2KbIGXi0SZWuwkZ2QNyfWdZW+TVfn84DpEP7rLeCt2UI6bJ8GwbQ==",
+          "dev": true,
+          "requires": {
+            "anymatch": "~3.1.2",
+            "braces": "~3.0.2",
+            "fsevents": "~2.3.2",
+            "glob-parent": "~5.1.2",
+            "is-binary-path": "~2.1.0",
+            "is-glob": "~4.0.1",
+            "normalize-path": "~3.0.0",
+            "readdirp": "~3.6.0"
+          }
+        },
+        "debug": {
+          "version": "3.2.7",
+          "resolved": "https://registry.npmjs.org/debug/-/debug-3.2.7.tgz",
+          "integrity": "sha512-CFjzYYAi4ThfiQvizrFQevTTXHtnCqWfe7x1AhgEscTz6ZbLbfoLRLPugTQyBth6f8ZERVUSyWHFD/7Wu4t1XQ==",
+          "dev": true,
+          "requires": {
+            "ms": "^2.1.1"
+          }
+        },
+        "fill-range": {
+          "version": "7.0.1",
+          "resolved": "https://registry.npmjs.org/fill-range/-/fill-range-7.0.1.tgz",
+          "integrity": "sha512-qOo9F+dMUmC2Lcb4BbVvnKJxTPjCm+RRpe4gDuGrzkL7mEVl/djYSu2OdQ2Pa302N4oqkSg9ir6jaLWJ2USVpQ==",
+          "dev": true,
+          "requires": {
+            "to-regex-range": "^5.0.1"
+          }
+        },
+        "fsevents": {
+          "version": "2.3.2",
+          "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.2.tgz",
+          "integrity": "sha512-xiqMQR4xAeHTuB9uWm+fFRcIOgKBMiOBP+eXiyT7jsgVCq1bkVygt00oASowB7EdtpOHaaPgKt812P9ab+DDKA==",
+          "dev": true,
+          "optional": true
+        },
+        "has-flag": {
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-3.0.0.tgz",
+          "integrity": "sha1-tdRU3CGZriJWmfNGfloH87lVuv0=",
+          "dev": true
+        },
+        "is-number": {
+          "version": "7.0.0",
+          "resolved": "https://registry.npmjs.org/is-number/-/is-number-7.0.0.tgz",
+          "integrity": "sha512-41Cifkg6e8TylSpdtTpeLVMqvSBEVzTttHvERD741+pnZ8ANv0004MRL43QKPDlK9cGvNp6NZWZUBlbGXYxxng==",
+          "dev": true
+        },
+        "ms": {
+          "version": "2.1.3",
+          "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
+          "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==",
+          "dev": true
+        },
+        "readdirp": {
+          "version": "3.6.0",
+          "resolved": "https://registry.npmjs.org/readdirp/-/readdirp-3.6.0.tgz",
+          "integrity": "sha512-hOS089on8RduqdbhvQ5Z37A0ESjsqz6qnRcffsMU3495FuTdqSm+7bhJ29JvIOsBDEEnan5DPu9t3To9VRlMzA==",
+          "dev": true,
+          "requires": {
+            "picomatch": "^2.2.1"
+          }
+        },
+        "semver": {
+          "version": "5.7.1",
+          "resolved": "https://registry.npmjs.org/semver/-/semver-5.7.1.tgz",
+          "integrity": "sha512-sauaDf/PZdVgrLTNYHRtpXa1iRiKcaebiKQ1BJdpQlWH2lCvexQdX55snPFyK7QzpudqbCI0qXFfOasHdyNDGQ==",
+          "dev": true
+        },
+        "supports-color": {
+          "version": "5.5.0",
+          "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-5.5.0.tgz",
+          "integrity": "sha512-QjVjwdXIt408MIiAqCX4oUKsgU2EqAGzs2Ppkm4aQYbjm+ZEWEcW4SfFNTr4uMNZma0ey4f5lgLrkB0aX0QMow==",
+          "dev": true,
+          "requires": {
+            "has-flag": "^3.0.0"
+          }
+        },
+        "to-regex-range": {
+          "version": "5.0.1",
+          "resolved": "https://registry.npmjs.org/to-regex-range/-/to-regex-range-5.0.1.tgz",
+          "integrity": "sha512-65P7iz6X5yEr1cwcgvQxbbIw7Uk3gOy5dIdtZ4rDveLqhrdJP+Li/Hx6tyK0NEb+2GCyneCMJiGqrADCSNk8sQ==",
+          "dev": true,
+          "requires": {
+            "is-number": "^7.0.0"
+          }
+        }
+      }
+    },
     "nopt": {
       "version": "3.0.6",
       "resolved": "https://registry.npmjs.org/nopt/-/nopt-3.0.6.tgz",
@@ -7363,6 +7895,12 @@
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/normalize-path/-/normalize-path-3.0.0.tgz",
       "integrity": "sha512-6eZs5Ls3WtCisHWp9S2GUy8dqkpGi4BVSz3GaqiE6ezub0512ESztXUwUB6C6IKbQkY2Pnb/mD4WYojCRwcwLA==",
+      "dev": true
+    },
+    "normalize-url": {
+      "version": "4.5.1",
+      "resolved": "https://registry.npmjs.org/normalize-url/-/normalize-url-4.5.1.tgz",
+      "integrity": "sha512-9UZCFRHQdNrfTpGg8+1INIg93B6zE0aXMVFkw1WFwvO4SlZywU6aLg5Of0Ap/PgcbSw4LNxvMWXMeugwMCX0AA==",
       "dev": true
     },
     "npm-run-path": {
@@ -7771,6 +8309,12 @@
       "integrity": "sha1-u+Z0BseaqFxc/sdm/lc0VV36EnQ=",
       "dev": true
     },
+    "p-cancelable": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/p-cancelable/-/p-cancelable-1.1.0.tgz",
+      "integrity": "sha512-s73XxOZ4zpt1edZYZzvhqFa6uvQc1vwUa0K0BdtIZgQMAJj9IbebH+JkgKZc9h+B05PKHLOTl4ajG1BmNrVZlw==",
+      "dev": true
+    },
     "p-each-series": {
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/p-each-series/-/p-each-series-2.1.0.tgz",
@@ -7826,6 +8370,26 @@
         "hasha": "^5.0.0",
         "lodash.flattendeep": "^4.4.0",
         "release-zalgo": "^1.0.0"
+      }
+    },
+    "package-json": {
+      "version": "6.5.0",
+      "resolved": "https://registry.npmjs.org/package-json/-/package-json-6.5.0.tgz",
+      "integrity": "sha512-k3bdm2n25tkyxcjSKzB5x8kfVxlMdgsbPr0GkZcwHsLpba6cBjqCt1KlcChKEvxHIcTB1FVMuwoijZ26xex5MQ==",
+      "dev": true,
+      "requires": {
+        "got": "^9.6.0",
+        "registry-auth-token": "^4.0.0",
+        "registry-url": "^5.0.0",
+        "semver": "^6.2.0"
+      },
+      "dependencies": {
+        "semver": {
+          "version": "6.3.0",
+          "resolved": "https://registry.npmjs.org/semver/-/semver-6.3.0.tgz",
+          "integrity": "sha512-b39TBaTSfV6yBrapU89p5fKekE2m/NwnDocOVruQFS1/veMgdzuPcnOM34M6CwxW8jH/lxEa5rBoDeUwu5HHTw==",
+          "dev": true
+        }
       }
     },
     "pad": {
@@ -7988,6 +8552,12 @@
       "integrity": "sha512-vkcDPrRZo1QZLbn5RLGPpg/WmIQ65qoWWhcGKf/b5eplkkarX0m9z8ppCat4mlOqUsWpyNuYgO3VRyrYHSzX5g==",
       "dev": true
     },
+    "prepend-http": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/prepend-http/-/prepend-http-2.0.0.tgz",
+      "integrity": "sha1-6SQ0v6XqjBn0HN/UAddBo8gZ2Jc=",
+      "dev": true
+    },
     "prettier": {
       "version": "1.19.1",
       "resolved": "https://registry.npmjs.org/prettier/-/prettier-1.19.1.tgz",
@@ -8108,6 +8678,12 @@
       "integrity": "sha512-RIdOzyoavK+hA18OGGWDqUTsCLhtA7IcZ/6NCs4fFJaHBDab+pDDmDIByWFRQJq2Cd7r1OoQxBGKOaztq+hjIQ==",
       "dev": true
     },
+    "pstree.remy": {
+      "version": "1.1.8",
+      "resolved": "https://registry.npmjs.org/pstree.remy/-/pstree.remy-1.1.8.tgz",
+      "integrity": "sha512-77DZwxQmxKnu3aR542U+X8FypNzbfJ+C5XQDk3uWjWxn6151aIMGthWYRXTqT1E5oJvg+ljaa2OJi+VfvCOQ8w==",
+      "dev": true
+    },
     "pump": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/pump/-/pump-3.0.0.tgz",
@@ -8123,6 +8699,15 @@
       "resolved": "https://registry.npmjs.org/punycode/-/punycode-2.1.1.tgz",
       "integrity": "sha512-XRsRjdf+j5ml+y/6GKHPZbrF/8p2Yga0JPtdqTIY2Xe5ohJPD9saDJJLPvp9+NSBprVvevdXZybnj2cv8OEd0A==",
       "dev": true
+    },
+    "pupa": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/pupa/-/pupa-2.1.1.tgz",
+      "integrity": "sha512-l1jNAspIBSFqbT+y+5FosojNpVpF94nlI+wDUpqP9enwOTfHx9f0gh5nB96vl+6yTpsJsypeNrwfzPrKuHB41A==",
+      "dev": true,
+      "requires": {
+        "escape-goat": "^2.0.0"
+      }
     },
     "qs": {
       "version": "6.7.0",
@@ -8165,6 +8750,26 @@
             "statuses": ">= 1.5.0 < 2",
             "toidentifier": "1.0.0"
           }
+        }
+      }
+    },
+    "rc": {
+      "version": "1.2.8",
+      "resolved": "https://registry.npmjs.org/rc/-/rc-1.2.8.tgz",
+      "integrity": "sha512-y3bGgqKj3QBdxLbLkomlohkvsA8gdAiUQlSBJnBhfn+BPxg4bc62d8TcBW15wavDfgexCgccckhcZvywyQYPOw==",
+      "dev": true,
+      "requires": {
+        "deep-extend": "^0.6.0",
+        "ini": "~1.3.0",
+        "minimist": "^1.2.0",
+        "strip-json-comments": "~2.0.1"
+      },
+      "dependencies": {
+        "strip-json-comments": {
+          "version": "2.0.1",
+          "resolved": "https://registry.npmjs.org/strip-json-comments/-/strip-json-comments-2.0.1.tgz",
+          "integrity": "sha1-PFMZQukIwml8DsNEhYwobHygpgo=",
+          "dev": true
         }
       }
     },
@@ -8275,6 +8880,24 @@
       "resolved": "https://registry.npmjs.org/regexpp/-/regexpp-3.1.0.tgz",
       "integrity": "sha512-ZOIzd8yVsQQA7j8GCSlPGXwg5PfmA1mrq0JP4nGhh54LaKN3xdai/vHUDu74pKwV8OxseMS65u2NImosQcSD0Q==",
       "dev": true
+    },
+    "registry-auth-token": {
+      "version": "4.2.1",
+      "resolved": "https://registry.npmjs.org/registry-auth-token/-/registry-auth-token-4.2.1.tgz",
+      "integrity": "sha512-6gkSb4U6aWJB4SF2ZvLb76yCBjcvufXBqvvEx1HbmKPkutswjW1xNVRY0+daljIYRbogN7O0etYSlbiaEQyMyw==",
+      "dev": true,
+      "requires": {
+        "rc": "^1.2.8"
+      }
+    },
+    "registry-url": {
+      "version": "5.1.0",
+      "resolved": "https://registry.npmjs.org/registry-url/-/registry-url-5.1.0.tgz",
+      "integrity": "sha512-8acYXXTI0AkQv6RAOjE3vOaIXZkT9wo4LOFbBKYQEEnnMNBpKqdUrI6S4NT0KPIo/WVvJ5tE/X5LF/TQUf0ekw==",
+      "dev": true,
+      "requires": {
+        "rc": "^1.2.8"
+      }
     },
     "release-zalgo": {
       "version": "1.0.0",
@@ -8432,6 +9055,15 @@
       "integrity": "sha1-LGN/53yJOv0qZj/iGqkIAGjiBSo=",
       "dev": true
     },
+    "responselike": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/responselike/-/responselike-1.0.2.tgz",
+      "integrity": "sha1-kYcg7ztjHFZCvgaPFa3lpG9Loec=",
+      "dev": true,
+      "requires": {
+        "lowercase-keys": "^1.0.0"
+      }
+    },
     "restore-cursor": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/restore-cursor/-/restore-cursor-2.0.0.tgz",
@@ -8570,6 +9202,23 @@
       "resolved": "https://registry.npmjs.org/semver/-/semver-7.3.2.tgz",
       "integrity": "sha512-OrOb32TeeambH6UrhtShmF7CRDqhL6/5XpPNp2DuRH6+9QLw/orhp72j87v8Qa1ScDkvrrBNpZcDejAirJmfXQ==",
       "dev": true
+    },
+    "semver-diff": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/semver-diff/-/semver-diff-3.1.1.tgz",
+      "integrity": "sha512-GX0Ix/CJcHyB8c4ykpHGIAvLyOwOobtM/8d+TQkAd81/bEjgPHrfba41Vpesr7jX/t8Uh+R3EX9eAS5be+jQYg==",
+      "dev": true,
+      "requires": {
+        "semver": "^6.3.0"
+      },
+      "dependencies": {
+        "semver": {
+          "version": "6.3.0",
+          "resolved": "https://registry.npmjs.org/semver/-/semver-6.3.0.tgz",
+          "integrity": "sha512-b39TBaTSfV6yBrapU89p5fKekE2m/NwnDocOVruQFS1/veMgdzuPcnOM34M6CwxW8jH/lxEa5rBoDeUwu5HHTw==",
+          "dev": true
+        }
+      }
     },
     "send": {
       "version": "0.16.2",
@@ -9391,6 +10040,12 @@
         }
       }
     },
+    "to-readable-stream": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/to-readable-stream/-/to-readable-stream-1.0.0.tgz",
+      "integrity": "sha512-Iq25XBt6zD5npPhlLVXGFN3/gyR2/qODcKNNyTMd4vbm39HUaOiAM4PMq0eMVC/Tkxz+Zjdsc55g9yyz+Yq00Q==",
+      "dev": true
+    },
     "to-regex": {
       "version": "3.0.2",
       "resolved": "https://registry.npmjs.org/to-regex/-/to-regex-3.0.2.tgz",
@@ -9417,6 +10072,26 @@
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/toidentifier/-/toidentifier-1.0.0.tgz",
       "integrity": "sha512-yaOH/Pk/VEhBWWTlhI+qXxDFXlejDGcQipMlyxda9nthulaxLZUNcUqFxokp0vcYnvteJln5FNQDRrxj3YcbVw=="
+    },
+    "touch": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/touch/-/touch-3.1.0.tgz",
+      "integrity": "sha512-WBx8Uy5TLtOSRtIq+M03/sKDrXCLHxwDcquSP2c43Le03/9serjQBIztjRz6FkJez9D/hleyAXTBGLwwZUw9lA==",
+      "dev": true,
+      "requires": {
+        "nopt": "~1.0.10"
+      },
+      "dependencies": {
+        "nopt": {
+          "version": "1.0.10",
+          "resolved": "https://registry.npmjs.org/nopt/-/nopt-1.0.10.tgz",
+          "integrity": "sha1-bd0hvSoxQXuScn3Vhfim83YI6+4=",
+          "dev": true,
+          "requires": {
+            "abbrev": "1"
+          }
+        }
+      }
     },
     "tough-cookie": {
       "version": "2.5.0",
@@ -9529,6 +10204,12 @@
       "integrity": "sha512-kBFT3U4Dcj4/pJ52vfjCSfyLyvG9VYYuGYPmrPvAxRw/i7xHiT4VvCev+uiEMcEEiu6UNB6KgWmGtSUYIWScbw==",
       "optional": true
     },
+    "undefsafe": {
+      "version": "2.0.5",
+      "resolved": "https://registry.npmjs.org/undefsafe/-/undefsafe-2.0.5.tgz",
+      "integrity": "sha512-WxONCrssBM8TSPRqN5EmsjVrsv4A8X12J4ArBiiayv3DyyG3ZlIg6yysuuSYdZsVz3TKcTg2fd//Ujd4CHV1iA==",
+      "dev": true
+    },
     "union-value": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/union-value/-/union-value-1.0.1.tgz",
@@ -9539,6 +10220,15 @@
         "get-value": "^2.0.6",
         "is-extendable": "^0.1.1",
         "set-value": "^2.0.1"
+      }
+    },
+    "unique-string": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/unique-string/-/unique-string-2.0.0.tgz",
+      "integrity": "sha512-uNaeirEPvpZWSgzwsPGtU2zVSTrn/8L5q/IexZmH0eH6SA73CmAA5U4GwORTxQAZs95TAXLNqeLoPPNO5gZfWg==",
+      "dev": true,
+      "requires": {
+        "crypto-random-string": "^2.0.0"
       }
     },
     "universalify": {
@@ -9592,6 +10282,49 @@
         }
       }
     },
+    "update-notifier": {
+      "version": "5.1.0",
+      "resolved": "https://registry.npmjs.org/update-notifier/-/update-notifier-5.1.0.tgz",
+      "integrity": "sha512-ItnICHbeMh9GqUy31hFPrD1kcuZ3rpxDZbf4KUDavXwS0bW5m7SLbDQpGX3UYr072cbrF5hFUs3r5tUsPwjfHw==",
+      "dev": true,
+      "requires": {
+        "boxen": "^5.0.0",
+        "chalk": "^4.1.0",
+        "configstore": "^5.0.1",
+        "has-yarn": "^2.1.0",
+        "import-lazy": "^2.1.0",
+        "is-ci": "^2.0.0",
+        "is-installed-globally": "^0.4.0",
+        "is-npm": "^5.0.0",
+        "is-yarn-global": "^0.3.0",
+        "latest-version": "^5.1.0",
+        "pupa": "^2.1.1",
+        "semver": "^7.3.4",
+        "semver-diff": "^3.1.1",
+        "xdg-basedir": "^4.0.0"
+      },
+      "dependencies": {
+        "chalk": {
+          "version": "4.1.2",
+          "resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.2.tgz",
+          "integrity": "sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA==",
+          "dev": true,
+          "requires": {
+            "ansi-styles": "^4.1.0",
+            "supports-color": "^7.1.0"
+          }
+        },
+        "semver": {
+          "version": "7.3.5",
+          "resolved": "https://registry.npmjs.org/semver/-/semver-7.3.5.tgz",
+          "integrity": "sha512-PoeGJYh8HK4BTO/a9Tf6ZG3veo/A7ZVsYrSA6J8ny9nb3B1VrpkuN+z9OE5wfE5p6H4LchYZsegiQgbJD94ZFQ==",
+          "dev": true,
+          "requires": {
+            "lru-cache": "^6.0.0"
+          }
+        }
+      }
+    },
     "uri-js": {
       "version": "4.4.0",
       "resolved": "https://registry.npmjs.org/uri-js/-/uri-js-4.4.0.tgz",
@@ -9606,6 +10339,15 @@
       "resolved": "https://registry.npmjs.org/urix/-/urix-0.1.0.tgz",
       "integrity": "sha1-2pN/emLiH+wf0Y1Js1wpNQZ6bHI=",
       "dev": true
+    },
+    "url-parse-lax": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/url-parse-lax/-/url-parse-lax-3.0.0.tgz",
+      "integrity": "sha1-FrXK/Afb42dsGxmZF3gj1lA6yww=",
+      "dev": true,
+      "requires": {
+        "prepend-http": "^2.0.0"
+      }
     },
     "use": {
       "version": "3.1.1",
@@ -9810,6 +10552,55 @@
         "string-width": "^1.0.2 || 2"
       }
     },
+    "widest-line": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/widest-line/-/widest-line-3.1.0.tgz",
+      "integrity": "sha512-NsmoXalsWVDMGupxZ5R08ka9flZjjiLvHVAWYOKtiKM8ujtZWr9cRffak+uSE48+Ob8ObalXpwyeUiyDD6QFgg==",
+      "dev": true,
+      "requires": {
+        "string-width": "^4.0.0"
+      },
+      "dependencies": {
+        "ansi-regex": {
+          "version": "5.0.1",
+          "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.1.tgz",
+          "integrity": "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==",
+          "dev": true
+        },
+        "emoji-regex": {
+          "version": "8.0.0",
+          "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-8.0.0.tgz",
+          "integrity": "sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A==",
+          "dev": true
+        },
+        "is-fullwidth-code-point": {
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-3.0.0.tgz",
+          "integrity": "sha512-zymm5+u+sCsSWyD9qNaejV3DFvhCKclKdizYaJUuHA83RLjb7nSuGnddCHGv0hk+KY7BMAlsWeK4Ueg6EV6XQg==",
+          "dev": true
+        },
+        "string-width": {
+          "version": "4.2.3",
+          "resolved": "https://registry.npmjs.org/string-width/-/string-width-4.2.3.tgz",
+          "integrity": "sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==",
+          "dev": true,
+          "requires": {
+            "emoji-regex": "^8.0.0",
+            "is-fullwidth-code-point": "^3.0.0",
+            "strip-ansi": "^6.0.1"
+          }
+        },
+        "strip-ansi": {
+          "version": "6.0.1",
+          "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.1.tgz",
+          "integrity": "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==",
+          "dev": true,
+          "requires": {
+            "ansi-regex": "^5.0.1"
+          }
+        }
+      }
+    },
     "winston": {
       "version": "2.1.1",
       "resolved": "https://registry.npmjs.org/winston/-/winston-2.1.1.tgz",
@@ -9942,6 +10733,12 @@
       "integrity": "sha512-YmhHDO4MzaDLB+M9ym/mDA5z0naX8j7SIlT8f8z+I0VtzsRbekxEutHSme7NPS2qE8StCYQNUnfWdXta/Yu85A==",
       "dev": true
     },
+    "xdg-basedir": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/xdg-basedir/-/xdg-basedir-4.0.0.tgz",
+      "integrity": "sha512-PSNhEJDejZYV7h50BohL09Er9VaIefr2LMAf3OEmpCkjOi34eYyQYAXUTjEQtZJTKcF0E2UKTh+osDLsgNim9Q==",
+      "dev": true
+    },
     "xml-name-validator": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/xml-name-validator/-/xml-name-validator-3.0.0.tgz",
@@ -9958,6 +10755,12 @@
       "version": "4.0.1",
       "resolved": "https://registry.npmjs.org/y18n/-/y18n-4.0.1.tgz",
       "integrity": "sha512-wNcy4NvjMYL8gogWWYAO7ZFWFfHcbdbE57tZO8e4cbpj8tfUcwrwqSl3ad8HxpYWCdXcJUCeKKZS62Av1affwQ==",
+      "dev": true
+    },
+    "yallist": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/yallist/-/yallist-4.0.0.tgz",
+      "integrity": "sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A==",
       "dev": true
     },
     "yaml": {

--- a/package.json
+++ b/package.json
@@ -43,6 +43,7 @@
     "locus": "^2.0.4",
     "mocha": "^8.1.3",
     "mocha-lcov-reporter": "^1.3.0",
+    "nodemon": "^2.0.15",
     "nyc": "^15.1.0"
   },
   "config": {

--- a/test/capital.js
+++ b/test/capital.js
@@ -41,7 +41,6 @@ describe('Capitals', () => {
           res.should.have.status(400);
           res.body.should.be.a('object');
           res.body.should.have.property('error').eql(true);
-          res.body.should.have.property('msg').eql('missing param (country)');
 
           done();
         });

--- a/test/cities.js
+++ b/test/cities.js
@@ -61,7 +61,6 @@ describe('Cities', () => {
           res.body.should.have.property('error').eql(false);
           res.body.should.have.property('data');
           res.body.should.have.property('data').be.a('array');
-          res.body.should.have.property('msg').be.a('string').eql(`cities in ${payload.country} retrieved`);
           done();
         });
     });

--- a/test/cityInState.js
+++ b/test/cityInState.js
@@ -116,7 +116,6 @@ describe('/POST', () => {
         res.body.should.be.a('object');
         res.body.should.have.property('error').eql(false);
         res.body.should.have.property('msg');
-        res.body.should.have.property('msg').eql(`cities in state ${payload.state} of country ${payload.country} retrieved`);
         res.body.should.have.property('data').be.a('array');
 
         done();

--- a/test/codes.js
+++ b/test/codes.js
@@ -101,7 +101,6 @@ describe('Codes', () => {
           res.should.have.status(200);
           res.body.should.be.a('object');
           res.body.should.have.property('error').eql(false);
-          res.body.should.have.property('msg').eql('nigeria dail code retrieved');
           res.body.should.have.property('data').be.a('object');
           res.body.data.should.have.property('dial_code').be.eql('+234');
 

--- a/test/flag.js
+++ b/test/flag.js
@@ -58,7 +58,6 @@ describe('Flags', () => {
           should.not.exist(err);
           res.body.should.be.a('object');
           res.body.should.have.property('error').eql(false);
-          res.body.should.have.property('msg').be.a('string').eql('countries and unicode flags retrieved');
           res.body.should.have.property('data').be.a('object').have.property('unicodeFlag');
           done();
         });
@@ -73,7 +72,6 @@ describe('Flags', () => {
           should.not.exist(err);
           res.body.should.be.a('object');
           res.body.should.have.property('error').eql(false);
-          res.body.should.have.property('msg').be.a('string').eql('flags images retrieved');
           res.body.should.have.property('data').be.a('array');
           res.body.data.length.should.not.equal(0);
           done();
@@ -107,8 +105,6 @@ describe('Flags', () => {
           should.not.exist(err);
           res.body.should.be.a('object');
           res.body.should.have.property('error').eql(false);
-          res.body.should.have.property('msg').be.a('string').eql('country and flag retrieved');
-          res.body.should.have.property('data').be.a('object').have.property('flag');
           done();
         });
     });

--- a/test/location.js
+++ b/test/location.js
@@ -106,7 +106,6 @@ describe('Capitals', () => {
           res.body.should.be.a('object');
           res.body.should.have.property('error').eql(true);
           res.body.should.have.property('msg');
-          res.body.should.have.property('msg').be.a('string').eql('missing param (type, min, max)');
 
           done();
         });
@@ -128,7 +127,6 @@ describe('Capitals', () => {
           res.body.should.be.a('object');
           res.body.should.have.property('error').eql(true);
           res.body.should.have.property('msg');
-          res.body.should.have.property('msg').be.a('string').eql('missing param (type, min, max)');
 
           done();
         });
@@ -150,7 +148,6 @@ describe('Capitals', () => {
           res.body.should.be.a('object');
           res.body.should.have.property('error').eql(true);
           res.body.should.have.property('msg');
-          res.body.should.have.property('msg').be.a('string').eql('missing param (type, min, max)');
 
           done();
         });

--- a/test/states.js
+++ b/test/states.js
@@ -43,7 +43,6 @@ describe('Population', () => {
           res.body.should.be.a('object');
           res.body.should.have.property('error').eql(true);
           res.body.should.have.property('msg');
-          res.body.should.have.property('msg').eql('missing param (country)');
 
           done();
         });
@@ -81,7 +80,6 @@ describe('Population', () => {
           res.body.should.be.a('object');
           res.body.should.have.property('error').eql(false);
           res.body.should.have.property('msg');
-          res.body.should.have.property('msg').eql(`states in ${payload.country} retrieved`);
           res.body.should.have.property('data').be.a('object');
           res.body.should.have.property('data').have.property('states');
 


### PR DESCRIPTION
- unicode flags: include `iso2` & `iso3` values in response
- population filter: include `iso3` value in response from datahub
- single country population: include `iso3` value in response
   - get single country by iso3 or country value
- single country location: query by country name or iso2
- get all countries and location: include iso2 value in response
- fix inconsistent naming for countries across endpoints
- single country and flag url: query by country name or iso2
- single country and unicode flag: query by country name or iso2
- get countries and flag url, get countries and unicode flag includes iso2 and iso3 values
- get countries and currencies: includes iso2 and iso3 values
- single country and currency: query by country name or iso2
- Get countries and their capital: include iso2 and iso3 values in response
- Get countries and cities: include iso2 and iso3 values in response
- Get cities by country: query by country name or iso2
- Get single country dial codes: query by country name or iso2

Closes #83, closes #81