### PR TITLE
:sparkles: (All GET routes in countries.js) Added route caching

### DIFF
--- a/.env
+++ b/.env
@@ -3,3 +3,4 @@ REDIS_PORT=6379
 TEST_PORT=4000
 DATA_HUB="https://pkgstore.datahub.io/core/"
 GITHUB_URL="https://raw.githubusercontent.com/"
+NODE_ENV="local"

--- a/config/apicache.js
+++ b/config/apicache.js
@@ -1,0 +1,33 @@
+const DEBUG_CONFIG = {
+    debug: true,
+    defaultDuration: '1 day',
+    enabled: true,
+    trackPerformance: true,
+    respectCacheControl: false
+};
+
+const UNIT_TEST_CONFIG = {
+    enabled: false
+};
+
+const PROD_CONFIG = {
+    debug: false,
+    defaultDuration: '1 day',
+    enabled: true,
+    trackPerformance: false,
+    respectCacheControl: false
+};
+
+switch(process.env.NODE_ENV) {
+    case 'local':
+        module.exports = DEBUG_CONFIG;
+        break;
+
+    case 'test':
+        module.exports = UNIT_TEST_CONFIG;
+        break;
+    
+    default:
+        module.exports = PROD_CONFIG;
+        break;
+}

--- a/package-lock.json
+++ b/package-lock.json
@@ -8,6 +8,7 @@
       "name": "country-city-api",
       "version": "0.0.0",
       "dependencies": {
+        "apicache": "^1.6.3",
         "axios": "^0.21.1",
         "body-parser": "^1.19.0",
         "cookie-parser": "~1.4.4",
@@ -1786,6 +1787,14 @@
       },
       "engines": {
         "node": ">= 8"
+      }
+    },
+    "node_modules/apicache": {
+      "version": "1.6.3",
+      "resolved": "https://registry.npmjs.org/apicache/-/apicache-1.6.3.tgz",
+      "integrity": "sha512-jS3VfUFpQ9BesFQZcdd1vVYg3ZsO2kGPmTJHqycIYPAQs54r74CRiyj8DuzJpwzLwIfCBYzh4dy9Jt8xYbo27w==",
+      "engines": {
+        "node": ">=8"
       }
     },
     "node_modules/append-transform": {
@@ -15330,6 +15339,11 @@
         "normalize-path": "^3.0.0",
         "picomatch": "^2.0.4"
       }
+    },
+    "apicache": {
+      "version": "1.6.3",
+      "resolved": "https://registry.npmjs.org/apicache/-/apicache-1.6.3.tgz",
+      "integrity": "sha512-jS3VfUFpQ9BesFQZcdd1vVYg3ZsO2kGPmTJHqycIYPAQs54r74CRiyj8DuzJpwzLwIfCBYzh4dy9Jt8xYbo27w=="
     },
     "append-transform": {
       "version": "2.0.0",

--- a/package.json
+++ b/package.json
@@ -15,6 +15,7 @@
     "coveralls": "nyc report --reporter=text-lcov | coveralls"
   },
   "dependencies": {
+    "apicache": "^1.6.3",
     "axios": "^0.21.1",
     "body-parser": "^1.19.0",
     "cookie-parser": "~1.4.4",

--- a/routes/countries.js
+++ b/routes/countries.js
@@ -1,8 +1,14 @@
 const express = require('express');
+const apicache = require('apicache');
+const apicacheConfig = require('../config/apicache');
 
 const router = express.Router();
 const CountryController = require('../controllers/countryController');
 const redirectPostToGet = require('../middlewares/redirectPostToGet');
+
+let cache = apicache.options(apicacheConfig).middleware;
+const cacheOnlyGET = cache('1 day', (req) => req.method === 'GET');
+router.use(cacheOnlyGET);
 
 // Redirect all POST requests to GET requests by appending /q and the request body as query parameters
 router.use(redirectPostToGet);


### PR DESCRIPTION
Added route caching for 24 hours on all GET routes in countries.js. Added caching configurations in /config/apicache.js
that are determined by NODE_ENV. Added default NODE_ENV = 'local' to .env - this enables caching with all debug output.
If NODE_ENV is set to 'test', caching is disabled (this prevents unit tests from using the cache). Any other value of
NODE_ENV will result in the production config being used.

Closes #94